### PR TITLE
Improve sidepanel UX and accessibility

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -43,6 +43,16 @@
                 {% block content %}{% endblock %}
             </div>
         </main>
+        <!-- Shared Application Panel -->
+        <div id="shared-application-panel"></div>
+        <script>
+            // Global ESC key handler for closing the panel
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') {
+                    document.dispatchEvent(new CustomEvent('close-panel'));
+                }
+            });
+        </script>
         <!-- Footer -->
         <footer class="bg-gray-100 border-t mt-12">
             <div class="container mx-auto px-4 py-8">

--- a/web/templates/partials/tiles/base_tile.html
+++ b/web/templates/partials/tiles/base_tile.html
@@ -39,9 +39,8 @@
                 {% block actions %}
                     {% if not current_case %}
                         {% block submit_button %}
-                            <button @click="showApplicationPanel = true"
-                                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+                                    hx-target="#shared-application-panel"
                                     hx-swap="innerHTML"
                                     class="w-full px-6 py-3 bg-blue-600 text-white text-center rounded-md hover:bg-blue-700 transition-colors">
                                 Aanvragen
@@ -144,9 +143,8 @@
                     <div class="flex items-center">
                         <h4 class="text-sm font-medium text-gray-500 mb-1">
                             U komt waarschijnlijk niet in aanmerking
-                            <button @click="showApplicationPanel = true"
-                                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                                    hx-target="#shared-application-panel"
                                     hx-swap="innerHTML"
                                     class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
                                 waarom?
@@ -160,9 +158,8 @@
                         U lijkt niet in aanmerking te komen voor deze regeling. Als u denkt dat u toch recht heeft kunt u
                         een aanvraag indienen.
                     </p>
-                    <button @click="showApplicationPanel = true"
-                            hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                            hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                    <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+                            hx-target="#shared-application-panel"
                             hx-swap="innerHTML"
                             class="w-full px-4 py-2 bg-gray-600 text-white text-center rounded-md hover:bg-gray-700 transition-colors">
                         Toch aanvragen
@@ -214,8 +211,6 @@
             </div>
         </dialog>
     {% endif %}
-    <div id="application-panel-{{ law|replace('/', '-') }}"
-         @click.outside="showApplicationPanel = false"></div>
 </div>
 <script>
     function showAppealDialog(caseId) {
@@ -227,4 +222,12 @@
         const dialog = document.getElementById(`objection-dialog-${caseId}`);
         dialog.close();
     }
+
+    // Listen for the close-panel event and close the shared panel
+    document.addEventListener('close-panel', function() {
+        const panel = document.getElementById('shared-application-panel');
+        if (panel) {
+            panel.innerHTML = '';
+        }
+    });
 </script>

--- a/web/templates/partials/tiles/components/application_panel.html
+++ b/web/templates/partials/tiles/components/application_panel.html
@@ -1,11 +1,12 @@
 {% from "macros/logos.html" import org_logo %}
 {% from "macros/render_path.html" import render_path, render_missing_required_form %}
 <div id="application-panel">
-    <div class="fixed inset-y-0 right-0 w-1/2 bg-white shadow-xl transform transition-transform duration-300 ease-in-out z-50 overflow-y-auto"
+    <div class="fixed inset-y-0 right-0 w-1/2 bg-white shadow-xl transform transition-transform duration-300 ease-in-out z-50 flex flex-col"
          x-data="{ show: true, showTechnical: false, showExplanation: {{ 'true' if request.query_params.get("default_tab") == 'explanation' else 'false' }}, showUsedData: false }"
          x-show="show"
          x-init="$nextTick(() => { show = true })"
          @click.away="$dispatch('close-panel')"
+         @keydown.escape="show = false; $dispatch('close-panel')"
          hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved=false"
          hx-trigger="edit-dialog-closed from:body"
          hx-target="#application-panel"
@@ -17,157 +18,167 @@
          x-transition:leave-start="translate-x-0"
          x-transition:leave-end="translate-x-full"
          style="display: none">
-        <div class="p-6 space-y-6">
-            <!-- Header with close button -->
+        <!-- Fixed header -->
+        <div class="p-6 border-b border-gray-200 bg-white z-10">
             <div class="flex justify-between items-start">
                 <div class="flex items-center space-x-3">
                     {% if service %}{{ org_logo(service) }}{% endif %}
                     <h3 class="text-lg font-semibold">{{ rule_spec.name if rule_spec else 'Loading...' }}</h3>
                 </div>
-                <button @click="show = false; $dispatch('close-panel')"
+                <button @click="show = false; $dispatch('close-panel'); document.getElementById('shared-application-panel').innerHTML = '';"
                         class="text-gray-500 hover:text-gray-700">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                 </button>
             </div>
-            <!-- Description -->
-            <div class="space-y-2">
-                <p class="text-sm text-gray-600">{{ rule_spec.description }}</p>
-            </div>
-            <!-- Toggle voor herberekenen - direct voor Result Summary -->
-            <div class="border-b pb-4 mb-4">
-                <div class="flex items-center justify-between">
-                    <h4 class="text-base font-medium text-gray-900">Reken met eigen aanpassingen in gegevens</h4>
-                    <label class="inline-flex items-center cursor-pointer">
-                        <input type="checkbox"
-                               class="sr-only peer"
-                               {% if request.query_params.get('approved', 'false') == 'false' %}checked{% endif %}
-                               hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ 'true' if request.query_params.get('approved', 'false') == 'false' else 'false' }}"
-                               hx-target="#application-panel"
-                               hx-swap="innerHTML"
-                               hx-trigger="change">
-                        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600">
-                        </div>
-                    </label>
-                </div>
-            </div>
-            <!-- Result Summary -->
-            {% set template = "partials/tiles/law/"+ law+ "/" + service + "/computation.html" %}
-            {% include [template, "partials/tiles/law/fallback/computation.html"] ignore missing %}
-            <!-- Missing Required Data Form -->
-            {{ render_missing_required_form(path, current_case.id|string if current_case else '', service, law, bsn, claim_map,
-                        show_approve=False, claimant="CITIZEN") }}
-            <!-- Used Data -->
-            <div class="border-t pt-4">
-                <button @click="showUsedData = !showUsedData"
-                        class="flex items-center justify-between w-full text-left">
-                    <span class="text-sm font-medium text-gray-900">Gebruikte gegevens</span>
-                    <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
-                         :class="{ 'rotate-180': showUsedData }"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-                <div x-show="showUsedData"
-                     x-transition:enter="transition ease-out duration-200"
-                     x-transition:enter-start="opacity-0 transform -translate-y-2"
-                     x-transition:enter-end="opacity-100 transform translate-y-0"
-                     x-transition:leave="transition ease-in duration-200"
-                     x-transition:leave-start="opacity-100 transform translate-y-0"
-                     x-transition:leave-end="opacity-0 transform -translate-y-2"
-                     class="mt-4">
-                    {{ render_path(path, current_case.id|string if current_case else '', service, law, bsn, claim_map,
-                                        show_approve=False, claimant="CITIZEN") }}
-                </div>
-            </div>
-            <!-- Submit Form -->
-            <div x-data="{ isChecked: false }" class="space-y-4">
-                <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
-                    <div class="flex items-center">
-                        <input type="checkbox"
-                               id="declaration-checkbox"
-                               x-model="isChecked"
-                               class="mr-3 rounded text-blue-600 focus:ring-blue-500">
-                        <label for="declaration-checkbox" class="font-medium">Ik verklaar dat mijn gegevens correct en volledig zijn</label>
+            <p class="text-sm text-gray-600 mt-2">{{ rule_spec.description }}</p>
+        </div>
+        <!-- Scrollable content -->
+        <div class="overflow-y-auto flex-grow">
+            <div class="p-6 space-y-6">
+                <!-- Toggle voor herberekenen - direct voor Result Summary -->
+                <div class="border-b pb-4 mb-4">
+                    <div class="flex items-center justify-between">
+                        <h4 class="text-base font-medium text-gray-900">Reken met eigen aanpassingen in gegevens</h4>
+                        <label class="inline-flex items-center cursor-pointer">
+                            <input type="checkbox"
+                                   class="sr-only peer"
+                                   {% if request.query_params.get('approved', 'false') == 'false' %}checked{% endif %}
+                                   hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ 'true' if request.query_params.get('approved', 'false') == 'false' else 'false' }}"
+                                   hx-target="#application-panel"
+                                   hx-swap="innerHTML"
+                                   hx-trigger="change">
+                            <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600">
+                            </div>
+                        </label>
                     </div>
-                    <p class="text-xs text-gray-500 mt-2 ml-7">Let op: Onjuiste informatie kan gevolgen hebben voor uw aanvraag.</p>
                 </div>
-                <form hx-post="/laws/submit-case?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ request.query_params.get('approved', 'false') }}"
-                      hx-target="closest div.law-result-card"
-                      hx-swap="outerHTML"
-                      class="mb-6">
-                    <input type="hidden" name="claimed_result" value="{{ result|tojson }}">
-                    <button type="submit"
-                            :disabled="!isChecked"
-                            :class="{ 'bg-blue-600 hover:bg-blue-700': isChecked, 'bg-gray-400 cursor-not-allowed': !isChecked }"
-                            class="w-full px-6 py-3 text-white text-center rounded-md transition-colors">
-                        Bevestig aanvraag
+                <!-- Result Summary -->
+                {% set template = "partials/tiles/law/"+ law+ "/" + service + "/computation.html" %}
+                {% include [template, "partials/tiles/law/fallback/computation.html"] ignore missing %}
+                <!-- Missing Required Data Form -->
+                {{ render_missing_required_form(path, current_case.id|string if current_case else '', service, law, bsn, claim_map,
+                                show_approve=False, claimant="CITIZEN") }}
+                <!-- Used Data -->
+                <div class="border-t pt-4">
+                    <button @click="showUsedData = !showUsedData"
+                            class="flex items-center justify-between w-full text-left">
+                        <span class="text-sm font-medium text-gray-900">Gebruikte gegevens</span>
+                        <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
+                             :class="{ 'rotate-180': showUsedData }"
+                             fill="none"
+                             stroke="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
                     </button>
-                </form>
-            </div>
-            <!-- Explanation Section -->
-            <div class="border-t pt-4">
-                <button @click="showExplanation = !showExplanation"
-                        class="flex items-center justify-between w-full text-left">
-                    <span class="text-sm font-medium text-gray-900">Uitleg</span>
-                    <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
-                         :class="{ 'rotate-180': showExplanation }"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-                <div x-show="showExplanation"
-                     x-transition:enter="transition ease-out duration-200"
-                     x-transition:enter-start="opacity-0 transform -translate-y-2"
-                     x-transition:enter-end="opacity-100 transform translate-y-0"
-                     x-transition:leave="transition ease-in duration-200"
-                     x-transition:leave-start="opacity-100 transform translate-y-0"
-                     x-transition:leave-end="opacity-0 transform -translate-y-2"
-                     class="mt-4">
-                    <div hx-get="/laws/explanation?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ request.query_params.get('approved', 'false') }}"
-                         hx-trigger="intersect once"
-                         hx-swap="innerHTML"
-                         hx-target="#explanation-content">
-                        <div id="explanation-content">{% include "partials/loading.html" %}</div>
+                    <div x-show="showUsedData"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 transform -translate-y-2"
+                         x-transition:enter-end="opacity-100 transform translate-y-0"
+                         x-transition:leave="transition ease-in duration-200"
+                         x-transition:leave-start="opacity-100 transform translate-y-0"
+                         x-transition:leave-end="opacity-0 transform -translate-y-2"
+                         class="mt-4">
+                        {{ render_path(path, current_case.id|string if current_case else '', service, law, bsn, claim_map,
+                                                show_approve=False, claimant="CITIZEN") }}
                     </div>
                 </div>
-            </div>
-            <!-- Technical Details Section -->
-            <div class="border-t pt-4">
-                <button @click="showTechnical = !showTechnical"
-                        class="flex items-center justify-between w-full text-left">
-                    <span class="text-sm font-medium text-gray-900">Technische details</span>
-                    <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
-                         :class="{ 'rotate-180': showTechnical }"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-                <div x-show="showTechnical"
-                     x-transition:enter="transition ease-out duration-200"
-                     x-transition:enter-start="opacity-0 transform -translate-y-2"
-                     x-transition:enter-end="opacity-100 transform translate-y-0"
-                     x-transition:leave="transition ease-in duration-200"
-                     x-transition:leave-start="opacity-100 transform translate-y-0"
-                     x-transition:leave-end="opacity-0 transform -translate-y-2"
-                     class="mt-4 space-y-4">
-                    <div class="space-y-2">
-                        <div class="text-xs text-gray-500 space-y-1">
-                            <div>Wet: {{ law }}</div>
-                            <div>Service: {{ service }}</div>
-                            <div>Geldig vanaf: {{ rule_spec.valid_from }}</div>
-                            <div>Versie: {{ rule_spec.uuid }}</div>
+                <!-- Submit Form -->
+                <div x-data="{ isChecked: false }" class="space-y-4">
+                    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
+                        <div class="flex items-center">
+                            <input type="checkbox"
+                                   id="declaration-checkbox"
+                                   x-model="isChecked"
+                                   class="mr-3 rounded text-blue-600 focus:ring-blue-500">
+                            <label for="declaration-checkbox" class="font-medium">Ik verklaar dat mijn gegevens correct en volledig zijn</label>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-2 ml-7">Let op: Onjuiste informatie kan gevolgen hebben voor uw aanvraag.</p>
+                    </div>
+                    <form hx-post="/laws/submit-case?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ request.query_params.get('approved', 'false') }}"
+                          hx-target="#tile-{{ law|replace('/', '-') }}"
+                          hx-swap="outerHTML"
+                          hx-on::after-request="document.getElementById('shared-application-panel').innerHTML = ''; document.dispatchEvent(new CustomEvent('close-panel'))"
+                          class="mb-6">
+                        <input type="hidden" name="claimed_result" value="{{ result|tojson }}">
+                        <button type="submit"
+                                :disabled="!isChecked"
+                                :class="{ 'bg-blue-600 hover:bg-blue-700': isChecked, 'bg-gray-400 cursor-not-allowed': !isChecked }"
+                                class="w-full px-6 py-3 text-white text-center rounded-md transition-colors">
+                            Bevestig aanvraag
+                        </button>
+                    </form>
+                </div>
+                <!-- Explanation Section -->
+                <div class="border-t pt-4">
+                    <button @click="showExplanation = !showExplanation"
+                            class="flex items-center justify-between w-full text-left">
+                        <span class="text-sm font-medium text-gray-900">Uitleg</span>
+                        <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
+                             :class="{ 'rotate-180': showExplanation }"
+                             fill="none"
+                             stroke="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div x-show="showExplanation"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 transform -translate-y-2"
+                         x-transition:enter-end="opacity-100 transform translate-y-0"
+                         x-transition:leave="transition ease-in duration-200"
+                         x-transition:leave-start="opacity-100 transform translate-y-0"
+                         x-transition:leave-end="opacity-0 transform -translate-y-2"
+                         class="mt-4">
+                        <div hx-get="/laws/explanation?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&approved={{ request.query_params.get('approved', 'false') }}"
+                             hx-trigger="intersect once"
+                             hx-swap="innerHTML"
+                             hx-target="#explanation-content">
+                            <div id="explanation-content">{% include "partials/loading.html" %}</div>
+                        </div>
+                    </div>
+                </div>
+                <!-- Technical Details Section -->
+                <div class="border-t pt-4">
+                    <button @click="showTechnical = !showTechnical"
+                            class="flex items-center justify-between w-full text-left">
+                        <span class="text-sm font-medium text-gray-900">Technische details</span>
+                        <svg class="w-5 h-5 text-gray-500 transform transition-transform duration-200"
+                             :class="{ 'rotate-180': showTechnical }"
+                             fill="none"
+                             stroke="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div x-show="showTechnical"
+                         x-transition:enter="transition ease-out duration-200"
+                         x-transition:enter-start="opacity-0 transform -translate-y-2"
+                         x-transition:enter-end="opacity-100 transform translate-y-0"
+                         x-transition:leave="transition ease-in duration-200"
+                         x-transition:leave-start="opacity-100 transform translate-y-0"
+                         x-transition:leave-end="opacity-0 transform -translate-y-2"
+                         class="mt-4 space-y-4">
+                        <div class="space-y-2">
+                            <div class="text-xs text-gray-500 space-y-1">
+                                <div>Wet: {{ law }}</div>
+                                <div>Service: {{ service }}</div>
+                                <div>Geldig vanaf: {{ rule_spec.valid_from }}</div>
+                                <div>Versie: {{ rule_spec.uuid }}</div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
+    <script>
+// Make sure the panel is closable with ESC even when not focused
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        document.dispatchEvent(new CustomEvent('close-panel'));
+    }
+});
+    </script>

--- a/web/templates/partials/tiles/law/algemene_ouderdomswet/SVB.html
+++ b/web/templates/partials/tiles/law/algemene_ouderdomswet/SVB.html
@@ -9,9 +9,8 @@
                     U vroeg eerder € {{ "%.2f"|format(current_case.claimed_result.pension_amount / 100) }} AOW aan.
                 </p>
                 <button type="button"
-                        @click="showApplicationPanel = true"
                         hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                        hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                        hx-target="#shared-application-panel"
                         hx-swap="innerHTML"
                         class="w-full px-4 py-2 bg-red-600 text-white text-center rounded-md hover:bg-red-700 transition-colors">
                     Vraag opnieuw aan
@@ -21,9 +20,8 @@
     {% endif %}
 {% endblock %}
 {% block submit_button %}
-    <button @click="showApplicationPanel = true"
-            hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-            hx-target="#application-panel-{{ law|replace('/', '-') }}"
+    <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+            hx-target="#shared-application-panel"
             hx-swap="innerHTML"
             class="w-full px-6 py-3 bg-blue-600 text-white text-center rounded-md hover:bg-blue-700 transition-colors">
         AOW aanvragen

--- a/web/templates/partials/tiles/law/algemene_ouderdomswet/SVB/computation.html
+++ b/web/templates/partials/tiles/law/algemene_ouderdomswet/SVB/computation.html
@@ -4,9 +4,8 @@
         <div class="flex items-baseline space-x-2">
             <span class="text-4xl font-bold text-blue-600">€ {{ "%.2f"|format(result.pension_amount / 100) }}</span>
             <span class="text-gray-500">per maand</span>
-            <button @click="showApplicationPanel = true"
-                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                    hx-target="#shared-application-panel"
                     hx-swap="innerHTML"
                     class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
                 waarom?

--- a/web/templates/partials/tiles/law/kieswet/KIESRAAD/computation.html
+++ b/web/templates/partials/tiles/law/kieswet/KIESRAAD/computation.html
@@ -8,9 +8,8 @@
         {% else %}
             <p class="text-4xl font-bold text-pink-600 mt-2">GEEN stemrecht</p>
         {% endif %}
-        <button @click="showApplicationPanel = true"
-                hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                hx-target="#application-panel-{{ law|replace('/', '-') }}"
+        <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                hx-target="#shared-application-panel"
                 hx-swap="innerHTML"
                 class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
             waarom?

--- a/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM.html
+++ b/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM.html
@@ -9,9 +9,8 @@
                     U vroeg eerder € {{ "%.2f"|format(current_case.claimed_result.benefit_amount / 100) }} bijstand aan.
                 </p>
                 <button type="button"
-                        @click="showApplicationPanel = true"
                         hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                        hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                        hx-target="#shared-application-panel"
                         hx-swap="innerHTML"
                         class="w-full px-4 py-2 bg-red-600 text-white text-center rounded-md hover:bg-red-700 transition-colors">
                     Vraag opnieuw aan
@@ -21,9 +20,8 @@
     {% endif %}
 {% endblock %}
 {% block submit_button %}
-    <button @click="showApplicationPanel = true"
-            hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-            hx-target="#application-panel-{{ law|replace('/', '-') }}"
+    <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+            hx-target="#shared-application-panel"
             hx-swap="innerHTML"
             class="w-full px-6 py-3 bg-purple-600 text-white text-center rounded-md hover:bg-purple-700 transition-colors">
         Bijstand aanvragen

--- a/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM/computation.html
+++ b/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM/computation.html
@@ -4,9 +4,8 @@
         <div class="flex items-baseline space-x-2">
             <span class="text-4xl font-bold text-purple-600">€ {{ "%.2f"|format(result.benefit_amount / 100) }}</span>
             <span class="text-gray-500">per maand</span>
-            <button @click="showApplicationPanel = true"
-                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                    hx-target="#shared-application-panel"
                     hx-swap="innerHTML"
                     class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
                 waarom?

--- a/web/templates/partials/tiles/law/wet_op_de_huurtoeslag/TOESLAGEN.html
+++ b/web/templates/partials/tiles/law/wet_op_de_huurtoeslag/TOESLAGEN.html
@@ -29,9 +29,8 @@
                     U vroeg eerder € {{ "%.2f"|format(current_case.claimed_result.subsidy_amount / 100) }} huurtoeslag aan.
                 </p>
                 <button type="button"
-                        @click="showApplicationPanel = true"
                         hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                        hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                        hx-target="#shared-application-panel"
                         hx-swap="innerHTML"
                         class="w-full px-4 py-2 bg-red-600 text-white text-center rounded-md hover:bg-red-700 transition-colors">
                     Vraag opnieuw aan
@@ -41,9 +40,8 @@
     {% endif %}
 {% endblock %}
 {% block submit_button %}
-    <button @click="showApplicationPanel = true"
-            hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-            hx-target="#application-panel-{{ law|replace('/', '-') }}"
+    <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+            hx-target="#shared-application-panel"
             hx-swap="innerHTML"
             class="w-full px-6 py-3 bg-indigo-600 text-white text-center rounded-md hover:bg-indigo-700 transition-colors">
         Huurtoeslag aanvragen

--- a/web/templates/partials/tiles/law/wet_op_de_huurtoeslag/TOESLAGEN/computation.html
+++ b/web/templates/partials/tiles/law/wet_op_de_huurtoeslag/TOESLAGEN/computation.html
@@ -4,9 +4,8 @@
         <div class="flex items-baseline">
             <span class="text-4xl font-bold text-indigo-600">€ {{ "%.2f"|format(result.subsidy_amount / 100) }}</span>
             <span class="ml-2 text-gray-600">per maand</span>
-            <button @click="showApplicationPanel = true"
-                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                    hx-target="#shared-application-panel"
                     hx-swap="innerHTML"
                     class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
                 waarom?

--- a/web/templates/partials/tiles/law/zorgtoeslagwet/TOESLAGEN.html
+++ b/web/templates/partials/tiles/law/zorgtoeslagwet/TOESLAGEN.html
@@ -9,9 +9,8 @@
                     U vroeg eerder € {{ "%.2f"|format(current_case.claimed_result.hoogte_toeslag / 100) }} zorgtoeslag aan.
                 </p>
                 <button type="button"
-                        @click="showApplicationPanel = true"
                         hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-                        hx-target="#application-panel-{{ law|replace('/', '-') }}"
+                        hx-target="#shared-application-panel"
                         hx-swap="innerHTML"
                         class="w-full px-4 py-2 bg-red-600 text-white text-center rounded-md hover:bg-red-700 transition-colors">
                     Vraag opnieuw aan
@@ -21,9 +20,8 @@
     {% endif %}
 {% endblock %}
 {% block submit_button %}
-    <button @click="showApplicationPanel = true"
-            hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
-            hx-target="#application-panel-{{ law|replace('/', '-') }}"
+    <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=application"
+            hx-target="#shared-application-panel"
             hx-swap="innerHTML"
             class="w-full px-6 py-3 bg-green-600 text-white text-center rounded-md hover:bg-green-700 transition-colors">
         Zorgtoeslag aanvragen

--- a/web/templates/partials/tiles/law/zorgtoeslagwet/TOESLAGEN/computation.html
+++ b/web/templates/partials/tiles/law/zorgtoeslagwet/TOESLAGEN/computation.html
@@ -4,9 +4,8 @@
         <div class="flex items-baseline">
             <span class="text-4xl font-bold text-green-600">€ {{ "%.2f"|format(result.hoogte_toeslag / 100) }}</span>
             <span class="ml-2 text-gray-600">per jaar</span>
-            <button @click="showApplicationPanel = true"
-                    hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
-                    hx-target="#application-panel-{{ law|replace('/', '-') }}"
+            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                    hx-target="#shared-application-panel"
                     hx-swap="innerHTML"
                     class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
                 waarom?


### PR DESCRIPTION
## Summary
- Converted to a single shared sidepanel instead of one per law tile (reduced code duplication)
- Made the panel header stay fixed when scrolling through content
- Added ESC key support for closing the panel
- Ensured panel closes automatically after form submission

## Test plan
- Open different law panels and verify they all use the same shared panel
- Scroll through a panel to verify the header remains fixed at the top
- Press ESC key to close an open panel
- Fill in a form and submit to verify panel closes on submission

🤖 Generated with Claude Code