### PR TITLE
Add kaniko Docker build validation workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,18 @@
+name: Docker Build Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Kaniko build (no push)
+      uses: aevea/action-kaniko@v0.10.0
+      with:
+        no_push: true
+        build_file: Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Docker Build Validation
+name: Docker Build Validation with Kaniko
 
 on:
   pull_request:
@@ -11,8 +11,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Kaniko build (no push)
-      uses: aevea/action-kaniko@v0.10.0
+    - name: Kaniko build
+      uses: docker/setup-qemu-action@v3
       with:
-        no_push: true
-        build_file: Dockerfile
+        platforms: amd64
+
+    - name: Run Kaniko build
+      uses: int128/kaniko-action@v1
+      with:
+        push: false
+        dockerfile: Dockerfile
+        context: .


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to validate Docker builds using kaniko. The workflow runs on pull requests and ensures that the Docker image builds successfully before merging.