### PR TITLE
Verbeter bijstandstegel met gedetailleerde specificatie

### DIFF
--- a/web/templates/partials/dashboard.html
+++ b/web/templates/partials/dashboard.html
@@ -3,8 +3,11 @@
 <section class="mb-8">
     <div class="flex justify-between items-start">
         <div>
-            <h2 class="text-2xl font-semibold text-gray-900 mb-2">Waar heb ik recht op?</h2>
-            <p class="text-gray-600">Bekijk hier uw toeslagen, uitkeringen en andere regelingen van de overheid.</p>
+            <h2 class="text-2xl font-semibold text-gray-900 mb-2">Waar heb ik recht op? Wat zijn mijn plichten?</h2>
+            <p class="text-gray-600">
+                Bekijk hier uw toeslagen, uitkeringen, aangiften, en andere regelingen van de
+                overheid.
+            </p>
         </div>
         <div class="flex items-center space-x-2">
             <span class="text-sm text-gray-600">Datum: {{ formatted_date }}</span>
@@ -214,6 +217,18 @@
             <li class="flex items-center">
                 <span class="w-4 h-4 bg-purple-200 rounded-full mr-2"></span>
                 <span>Bijstand (Participatiewet)</span>
+            </li>
+            <li class="flex items-center">
+                <span class="w-4 h-4 bg-blue-200 rounded-full mr-2"></span>
+                <span>Inkomstenbelasting</span>
+            </li>
+            <li class="flex items-center">
+                <span class="w-4 h-4 bg-indigo-200 rounded-full mr-2"></span>
+                <span>Huurtoeslag</span>
+            </li>
+            <li class="flex items-center">
+                <span class="w-4 h-4 bg-pink-200 rounded-full mr-2"></span>
+                <span>Kieswet</span>
             </li>
         </ul>
     </div>

--- a/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM/computation.html
+++ b/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM/computation.html
@@ -1,9 +1,9 @@
 <div>
     {% if result.benefit_amount %}
-        <h4 class="text-sm font-medium text-gray-500 mb-1">Uw bijstandsuitkering is waarschijnlijk</h4>
-        <div class="flex items-baseline space-x-2">
+        <h4 class="text-sm font-medium text-gray-600 mb-2">Uw bijstandsuitkering is waarschijnlijk</h4>
+        <div class="flex items-baseline">
             <span class="text-4xl font-bold text-purple-600">€ {{ "%.2f"|format(result.benefit_amount / 100) }}</span>
-            <span class="text-gray-500">per maand</span>
+            <span class="ml-2 text-gray-600">per maand</span>
             <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
                     hx-target="#shared-application-panel"
                     hx-swap="innerHTML"
@@ -11,7 +11,40 @@
                 waarom?
             </button>
         </div>
+        <div class="mt-4 bg-gray-50 p-3 rounded-lg">
+            <h5 class="text-sm font-medium text-gray-700 mb-2">Specificatie bijstand</h5>
+            <div class="grid grid-cols-2 gap-1 text-sm">
+                <div class="text-gray-600">Basisbedrag (met kostendelersnorm):</div>
+                <div class="text-right font-medium">
+                    € {{ "%.2f"|format((result.benefit_amount - result.housing_assistance) / 100) }}
+                </div>
+                {% if result.housing_assistance > 0 %}
+                    <div class="text-gray-600">Woonkostentoeslag (briefadres):</div>
+                    <div class="text-right font-medium text-purple-600">€ {{ "%.2f"|format(result.housing_assistance / 100) }}</div>
+                {% endif %}
+                {% if result.startup_assistance > 0 %}
+                    <div class="text-gray-600">ZZP vrijlating:</div>
+                    <div class="text-right font-medium text-purple-600">inkomsten vrijlating 20%</div>
+                {% endif %}
+                <div class="text-gray-800 font-medium mt-2 pt-2 border-t border-gray-200">Totaal uitkering per maand:</div>
+                <div class="text-right font-medium mt-2 pt-2 border-t border-gray-200">
+                    € {{ "%.2f"|format(result.benefit_amount / 100) }}
+                </div>
+                {% if result.startup_assistance > 0 %}
+                    <div class="text-gray-800 font-medium mt-2">Eenmalig bedrijfskapitaal:</div>
+                    <div class="text-right font-medium mt-2 text-purple-600">€ {{ "%.2f"|format(result.startup_assistance / 100) }}</div>
+                {% endif %}
+            </div>
+        </div>
     {% else %}
-        <h4 class="text-sm font-medium text-gray-500 mb-1">U krijgt waarschijnlijk geen bijstandsuitkering.</h4>
+        <h4 class="text-sm font-medium text-gray-500 mb-1">
+            U krijgt waarschijnlijk geen bijstandsuitkering.
+            <button hx-get="/laws/application-panel?service={{ service }}&law={{ law|urlencode }}&bsn={{ bsn }}&default_tab=explanation"
+                    hx-target="#shared-application-panel"
+                    hx-swap="innerHTML"
+                    class="ml-4 text-sm text-gray-400 hover:text-gray-900 border-b border-dotted border-gray-300 hover:border-gray-600">
+                waarom?
+            </button>
+        </h4>
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- Voegt een gedetailleerde specificatie toe aan de bijstandstegel van Amsterdam, vergelijkbaar met de inkomstenbelastingtegel
- Breekt het bijstandsbedrag op in basisbedrag, woonkostentoeslag, ZZP-vrijlating en toont eenmalig bedrijfskapitaal apart

## Test plan
- Open de website en navigeer naar de bijstandstegel van Amsterdam
- Controleer of de specificatie correct wordt weergegeven met basisbedrag, toeslagen en eventueel bedrijfskapitaal
- Test verschillende scenario's om te zien of conditionele onderdelen (woonkostentoeslag, bedrijfskapitaal) correct worden getoond of verborgen

🤖 Generated with [Claude Code](https://claude.ai/code)