### PR TITLE
Remove 'Nieuwe Simulatie' from navbar and update zero state

### DIFF
--- a/web/templates/simulation.html
+++ b/web/templates/simulation.html
@@ -758,7 +758,7 @@
                             de toepassing van alle beschikbare wetten.
                         </p>
                         <p class="mt-2 text-sm text-gray-600">U kunt de parameters aanpassen om verschillende scenario's te testen.</p>
-                        <p class="mt-6 text-base text-gray-700 font-medium">Klik op "Nieuwe Simulatie" om te beginnen</p>
+                        <p class="mt-6 text-base text-gray-700 font-medium">Klik op "Nieuwe Simulatie" hier links om te beginnen</p>
                     </div>
                 </div>
             </div>

--- a/web/templates/simulation_base.html
+++ b/web/templates/simulation_base.html
@@ -50,14 +50,6 @@
                                     <span class="text-xl font-semibold">Machine Law Simulator</span>
                                 </a>
                             </h1>
-                            <!-- Desktop Navigation -->
-                            <nav class="hidden lg:block ml-8">
-                                <ul class="flex space-x-6">
-                                    <li>
-                                        <a href="/simulation" class="text-gray-300 hover:text-white font-medium">Nieuwe Simulatie</a>
-                                    </li>
-                                </ul>
-                            </nav>
                         </div>
                         <!-- Right side: Navigation menu -->
                         <div class="flex items-center">


### PR DESCRIPTION
## Summary
- Removed 'Nieuwe Simulatie' link from top navigation bar  
- Updated zero state message to direct users to click 'Nieuwe Simulatie' on the left sidebar
- Creates cleaner navigation experience focusing on the left sidebar controls

## Changes
- Removed the navigation section from `simulation_base.html` that contained the 'Nieuwe Simulatie' link
- Updated the zero state message in `simulation.html` from "Klik op 'Nieuwe Simulatie' om te beginnen" to "Klik op 'Nieuwe Simulatie' hier links om te beginnen"

## Why
As requested after the previous PR was merged, the 'Nieuwe Simulatie' link in the top navbar is redundant since users can click the button in the left sidebar. The zero state now clearly directs users to the left sidebar button.

🤖 Generated with [Claude Code](https://claude.ai/code)