### PR TITLE
feat: add WPM law stub and upgrade schema to v0.1.6

### DIFF
--- a/law/algemene_ouderdomswet/SVB-2024-01-01.yaml
+++ b/law/algemene_ouderdomswet/SVB-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 13dc8a31-91eb-4598-998c-012c9129b9ea
 name: AOW-uitkering
 law: algemene_ouderdomswet

--- a/law/algemene_ouderdomswet/leeftijdsbepaling/SVB-2024-01-01.yaml
+++ b/law/algemene_ouderdomswet/leeftijdsbepaling/SVB-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 47fa262a-b8f7-43bf-a5dd-5f9b2d2c1228
 name: Bepalen AOW-leeftijd 2025
 law: algemene_ouderdomswet/leeftijdsbepaling

--- a/law/awb/beroep/JenV-2024-01-01.yaml
+++ b/law/awb/beroep/JenV-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: c4fda809-15f2-454a-9e9b-f645b905ca12
 name: Algemene wet bestuursrecht - Beroepmogelijkheid en Termijnen
 law: awb/beroep

--- a/law/awb/bezwaar/JenV-2024-01-01.yaml
+++ b/law/awb/bezwaar/JenV-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: b6679cca-4555-44b4-9b8f-caa6886b74a0
 name: Algemene wet bestuursrecht - Bezwaarmogelijkheid en Termijnen
 law: awb/bezwaar

--- a/law/handelsregisterwet/KVK-2024-01-01.yaml
+++ b/law/handelsregisterwet/KVK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 8b59ef92-03f8-4294-bce9-4eaac01ba0ed
 name: Bepalen ondernemerschap
 law: handelsregisterwet

--- a/law/kieswet/KIESRAAD-2024-01-01.yaml
+++ b/law/kieswet/KIESRAAD-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 96d926a0-b45f-4cf3-92af-01b167221a00
 name: Kiesrecht Tweede Kamer
 law: kieswet

--- a/law/participatiewet/bijstand/SZW-2023-01-01.yaml
+++ b/law/participatiewet/bijstand/SZW-2023-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: c00f6a8b-b387-45d0-ab15-6f5aa34b7287
 name: Bepalen recht op bijstand landelijk
 law: participatiewet/bijstand

--- a/law/participatiewet/bijstand/gemeenten/GEMEENTE_AMSTERDAM-2023-01-01.yaml
+++ b/law/participatiewet/bijstand/gemeenten/GEMEENTE_AMSTERDAM-2023-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: b1d3a15b-45a2-44a3-b26a-d636785032c0
 name: Bijstand Gemeente Amsterdam
 law: participatiewet/bijstand

--- a/law/penitentiaire_beginselenwet/DJI-2022-01-01.yaml
+++ b/law/penitentiaire_beginselenwet/DJI-2022-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 292c11ff-8318-4b7a-bb11-3ea545b04c8e
 name: Bepalen detentiestatus
 law: penitentiaire_beginselenwet

--- a/law/vreemdelingenwet/IND-2024-01-01.yaml
+++ b/law/vreemdelingenwet/IND-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: af0fed0d-ee11-48f3-b629-07becda4b7e9
 name: Bepalen verblijfsstatus
 law: vreemdelingenwet

--- a/law/wet_brp/RvIG-2020-01-01.yaml
+++ b/law/wet_brp/RvIG-2020-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: fcf09c18-1584-4565-9223-e8a86fbddc09
 name: Bepalen persoonsgegevens BRP
 law: wet_brp

--- a/law/wet_forensische_zorg/DJI-2022-01-01.yaml
+++ b/law/wet_forensische_zorg/DJI-2022-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: c2124946-50d3-4aa8-b510-bccd04fc2cf9
 name: Bepalen forensische zorg status
 law: wet_forensische_zorg

--- a/law/wet_inkomstenbelasting/BELASTINGDIENST-2001-01-01.yaml
+++ b/law/wet_inkomstenbelasting/BELASTINGDIENST-2001-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: cdd0ec9f-4975-4969-9d8a-808f2d6abfc9
 name: Inkomstenbelasting
 law: wet_inkomstenbelasting

--- a/law/wet_inkomstenbelasting/UWV-2020-01-01.yaml
+++ b/law/wet_inkomstenbelasting/UWV-2020-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 06c43099-444f-415d-a98a-cb686954ed24
 name: Bepalen toetsingsinkomen
 law: wet_inkomstenbelasting

--- a/law/wet_kinderopvang/TOESLAGEN-2024-01-01.yaml
+++ b/law/wet_kinderopvang/TOESLAGEN-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: f8e7d6c5-4321-4f0f-bbbb-123456789abc
 name: Bepalen kinderopvangtoeslag
 law: wet_kinderopvang

--- a/law/wet_op_het_centraal_bureau_voor_de_statistiek/CBS-2024-01-01.yaml
+++ b/law/wet_op_het_centraal_bureau_voor_de_statistiek/CBS-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: bfc4ce3d-1c52-4fb8-ad96-4f1b9d836c4a
 name: Bepalen levensverwachting 2025
 law: wet_op_het_centraal_bureau_voor_de_statistiek

--- a/law/wet_structuur_uitvoeringsorganisatie_werk_en_inkomen/UWV-2024-01-01.yaml
+++ b/law/wet_structuur_uitvoeringsorganisatie_werk_en_inkomen/UWV-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: c19a458e-3f5e-4d99-a7c3-67a4288aaa07
 name: Bepalen verzekerde jaren 2025
 law: wet_structuur_uitvoeringsorganisatie_werk_en_inkomen

--- a/law/wet_studiefinanciering/DUO-2024-01-01.yaml
+++ b/law/wet_studiefinanciering/DUO-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: e3bb489c-b7d1-49dd-985c-a3cde1ab0ad3
 name: Bepalen studiefinanciering 2024
 law: wet_studiefinanciering

--- a/law/wetboek_van_strafrecht/JUSTID-2023-01-01.yaml
+++ b/law/wetboek_van_strafrecht/JUSTID-2023-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 41ffa9a4-89a6-4fed-acc7-6b4fdb2e56ce
 name: Bepalen uitsluiting kiesrecht
 law: wetboek_van_strafrecht

--- a/law/wpm/WPM-2024-01-01.yaml
+++ b/law/wpm/WPM-2024-01-01.yaml
@@ -1,0 +1,38 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 12345678-1234-4678-8abc-123456789abc
+name: WPM
+law: wpm
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "TOEKENNING"
+discoverable: "BUSINESS"
+valid_from: 2024-01-01
+service: "RVO"
+description: >
+  WPM wetgeving - placeholder implementatie voor RVO
+
+legal_basis:
+  law: "WPM"
+  bwb_id: "BWBR0001234"
+  article: "1"
+  url: "https://example.com/wpm"
+  juriconnect: "jci1.3:c:BWBR0001234&artikel=1&z=2024-01-01&g=2024-01-01"
+  explanation: "Placeholder artikel voor WPM wetgeving"
+
+references:
+  - law: "WPM"
+    article: "1"
+    url: "https://example.com/wpm"
+
+properties:
+  parameters:
+    - name: "kvk-nummer"
+      description: "KvK nummer van de onderneming"
+      type: "string"
+      required: true
+
+  output:
+    - name: "eligible"
+      description: "Of de onderneming in aanmerking komt"
+      type: "boolean"
+      default: false

--- a/law/zorgtoeslagwet/TOESLAGEN-2024-01-01.yaml
+++ b/law/zorgtoeslagwet/TOESLAGEN-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.4/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 5be9dbe7-f565-40e2-8931-da82825dcf21
 name: Zorgtoeslag
 law: zorgtoeslagwet

--- a/law/zorgtoeslagwet/TOESLAGEN-2025-01-01.yaml
+++ b/law/zorgtoeslagwet/TOESLAGEN-2025-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 60e71675-38bc-4297-87ac-0c145613e481
 name: Zorgtoeslag
 law: zorgtoeslagwet

--- a/law/zorgtoeslagwet/regelingen/vaststelling_standaardpremie_2024_01_01.yaml
+++ b/law/zorgtoeslagwet/regelingen/vaststelling_standaardpremie_2024_01_01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: ce827aca-e943-4588-bc49-457650f68b04
 name: Vaststellen standaardpremie
 law: zorgtoeslagwet/regelingen/regeling_vaststelling_standaardpremie_en_bestuursrechtelijke_premies

--- a/law/zorgtoeslagwet/regelingen/vaststelling_standaardpremie_2025_01_01.yaml
+++ b/law/zorgtoeslagwet/regelingen/vaststelling_standaardpremie_2025_01_01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: ac962262-6628-49bf-a465-5d831271936a
 name: Vaststellen standaardpremie
 law: zorgtoeslagwet/regelingen/regeling_vaststelling_standaardpremie_en_bestuursrechtelijke_premies

--- a/law/zvw/RVZ-2024-01-01.yaml
+++ b/law/zvw/RVZ-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.5/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: aba2b8fa-4b34-420f-883a-e78da326a8f4
 name: Bepalen verzekeringsstatus 2024
 law: zvw

--- a/schema/v0.1.6/schema.json
+++ b/schema/v0.1.6/schema.json
@@ -1,0 +1,748 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json",
+  "title": "Dutch Government Service Definition",
+  "type": "object",
+  "required": [
+    "uuid",
+    "name",
+    "law",
+    "valid_from",
+    "service",
+    "description",
+    "properties"
+  ],
+  "properties": {
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "name": {
+      "type": "string"
+    },
+    "law": {
+      "type": "string"
+    },
+    "law_type": {
+      "type": "string",
+      "enum": [
+        "FORMELE_WET"
+      ]
+    },
+    "legal_character": {
+      "type": "string",
+      "enum": [
+        "BESCHIKKING",
+        "BESLUIT_VAN_ALGEMENE_STREKKING"
+      ]
+    },
+    "decision_type": {
+      "type": "string",
+      "enum": [
+        "TOEKENNING",
+        "ALGEMEEN_VERBINDEND_VOORSCHRIFT",
+        "BELEIDSREGEL",
+        "VOORBEREIDINGSBESLUIT",
+        "ANDERE_HANDELING",
+        "AANSLAG"
+      ]
+    },
+    "discoverable": {
+      "type": "string",
+      "enum": [
+        "CITIZEN",
+        "BUSINESS"
+      ]
+    },
+    "valid_from": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "service": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "law",
+          "article",
+          "url"
+        ],
+        "properties": {
+          "law": {
+            "type": "string"
+          },
+          "article": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "legal_basis": {
+      "$ref": "#/definitions/legalBasis"
+    },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/parameterField"
+          }
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/sourceField"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputField"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputField"
+          }
+        },
+        "definitions": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "baseField": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "amount",
+            "object",
+            "array",
+            "date"
+          ]
+        },
+        "type_spec": {
+          "type": "object",
+          "properties": {
+            "unit": {
+              "type": "string",
+              "enum": [
+                "eurocent",
+                "years",
+                "weeks",
+                "months"
+              ]
+            },
+            "precision": {
+              "type": "number",
+              "minimum": 0
+            },
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            }
+          }
+        },
+        "temporal": {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "period",
+                "point_in_time"
+              ]
+            },
+            "period_type": {
+              "type": "string",
+              "enum": [
+                "year",
+                "month",
+                "continuous"
+              ]
+            },
+            "reference": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "$calculation_date",
+                    "$prev_january_first",
+                    "$january_first"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/variableReference"
+                }
+              ]
+            },
+            "immutable_after": {
+              "type": "string",
+              "pattern": "^P[0-9]+[YMD]$"
+            }
+          }
+        },
+        "legal_basis": {
+          "$ref": "#/definitions/legalBasis"
+        }
+      }
+    },
+    "variableReference": {
+      "type": "string",
+      "pattern": "^\\$[A-Z_][A-Z0-9_]*(?:\\.[A-Z_][A-Z0-9_]*)*$"
+    },
+    "parameterField": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/baseField"
+        },
+        {
+          "properties": {
+            "required": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "sourceField": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/baseField"
+        },
+        {
+          "properties": {
+            "source_reference": {
+              "$ref": "#/definitions/sourceReference"
+            },
+            "service_reference": {
+              "$ref": "#/definitions/serviceReference"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "source_reference"
+              ]
+            },
+            {
+              "required": [
+                "service_reference"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "inputField": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/baseField"
+        },
+        {
+          "properties": {
+            "service_reference": {
+              "$ref": "#/definitions/serviceReference"
+            }
+          },
+          "required": [
+            "service_reference"
+          ]
+        }
+      ]
+    },
+    "outputField": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/baseField"
+        },
+        {
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      ]
+    },
+    "sourceReference": {
+      "type": "object",
+      "properties": {
+        "source_type": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "select_on": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "description",
+              "type",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/valueOperation"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "serviceReference": {
+      "type": "object",
+      "required": [
+        "service",
+        "field",
+        "law"
+      ],
+      "properties": {
+        "service": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "law": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "reference"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "reference": {
+                "type": "string",
+                "pattern": "^\\$[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "valueOperation": {
+      "type": "object",
+      "required": [
+        "operation"
+      ],
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ADD",
+            "SUBTRACT",
+            "MULTIPLY",
+            "DIVIDE",
+            "IN",
+            "NOT_IN",
+            "EQUALS",
+            "NOT_EQUALS"
+          ]
+        },
+        "values": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/variableReference"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/variableReference"
+                  },
+                  {
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "operation": {
+      "type": "object",
+      "required": [
+        "operation"
+      ],
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ADD",
+            "SUBTRACT",
+            "MULTIPLY",
+            "DIVIDE",
+            "MIN",
+            "MAX",
+            "AND",
+            "OR",
+            "NOT",
+            "EQUALS",
+            "NOT_EQUALS",
+            "GREATER_THAN",
+            "LESS_THAN",
+            "GREATER_OR_EQUAL",
+            "LESS_OR_EQUAL",
+            "IN",
+            "NOT_IN",
+            "CONCAT",
+            "IF",
+            "FOREACH",
+            "SUBTRACT_DATE"
+          ]
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operationValue"
+          }
+        },
+        "subject": {
+          "$ref": "#/definitions/variableReference"
+        },
+        "value": {
+          "$ref": "#/definitions/operationValue"
+        },
+        "legal_basis": {
+          "$ref": "#/definitions/legalBasis"
+        }
+      },
+      "additionalProperties": false
+    },
+    "operationValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/variableReference"
+        },
+        {
+          "type": [
+            "number",
+            "boolean",
+            "null"
+          ]
+        },
+        {
+          "type": "string",
+          "not": {
+            "pattern": "^\\$"
+          }
+        },
+        {
+          "$ref": "#/definitions/operation"
+        }
+      ]
+    },
+    "action": {
+      "type": "object",
+      "required": [
+        "output"
+      ],
+      "properties": {
+        "output": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/operationValue"
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ADD",
+            "SUBTRACT",
+            "MULTIPLY",
+            "DIVIDE",
+            "MIN",
+            "MAX",
+            "AND",
+            "OR",
+            "NOT",
+            "EQUALS",
+            "NOT_EQUALS",
+            "GREATER_THAN",
+            "LESS_THAN",
+            "GREATER_OR_EQUAL",
+            "LESS_OR_EQUAL",
+            "IN",
+            "NOT_IN",
+            "CONCAT",
+            "IF",
+            "FOREACH",
+            "SUBTRACT_DATE"
+          ]
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operationValue"
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "test": {
+                "$ref": "#/definitions/operation"
+              },
+              "then": {
+                "$ref": "#/definitions/operationValue"
+              },
+              "else": {
+                "$ref": "#/definitions/operationValue"
+              },
+              "legal_basis": {
+                "$ref": "#/definitions/legalBasis"
+              }
+            },
+            "required": [
+              "test",
+              "then"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "legal_basis": {
+          "$ref": "#/definitions/legalBasis"
+        }
+      },
+      "additionalProperties": false
+    },
+    "requirement": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/requirement"
+              }
+            }
+          },
+          "required": [
+            "all"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/requirement"
+              }
+            }
+          },
+          "required": [
+            "any"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "or": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/requirement"
+              }
+            }
+          },
+          "required": [
+            "or"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "EQUALS",
+                "NOT_EQUALS",
+                "GREATER_THAN",
+                "LESS_THAN",
+                "GREATER_OR_EQUAL",
+                "LESS_OR_EQUAL",
+                "IN",
+                "NOT_IN",
+                "IS_NULL",
+                "NOT_NULL"
+              ]
+            },
+            "subject": {
+              "$ref": "#/definitions/variableReference"
+            },
+            "value": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/variableReference"
+                },
+                {
+                  "type": [
+                    "number",
+                    "boolean"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "not": {
+                    "pattern": "^\\$"
+                  }
+                }
+              ]
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/variableReference"
+                  },
+                  {
+                    "type": [
+                      "number",
+                      "boolean"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "not": {
+                      "pattern": "^\\$"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "operation"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "legalBasis": {
+      "type": "object",
+      "required": [
+        "law",
+        "url",
+        "explanation"
+      ],
+      "properties": {
+        "law": {
+          "type": "string",
+          "description": "Naam van de wet"
+        },
+        "bwb_id": {
+          "type": "string",
+          "pattern": "^BWBR[0-9]{7}$",
+          "description": "BWB identificatienummer van de wet"
+        },
+        "article": {
+          "type": "string",
+          "description": "Artikelnummer"
+        },
+        "paragraph": {
+          "type": "string",
+          "description": "Lid- of paragraafnummer"
+        },
+        "sentence": {
+          "type": "string",
+          "description": "Zinsnummer voor fijnmazige verwijzing"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL naar wetten.overheid.nl"
+        },
+        "juriconnect": {
+          "type": "string",
+          "pattern": "^jci1\\.3:c:BWBR[0-9]{7}(&[a-zA-Z_]+=.+)*$",
+          "description": "Juriconnect BWB 1.3 verwijzing"
+        },
+        "explanation": {
+          "type": "string",
+          "description": "Nederlandse uitleg hoe dit element zich verhoudt tot de wettekst"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/script/validate.py
+++ b/script/validate.py
@@ -177,7 +177,7 @@ def validate_variable_definitions(yaml_files: List[Path]) -> None:
 
 def main():
     BASE_DIR = Path("law")
-    schema = "schema/v0.1.4/schema.json"
+    schema = "schema/v0.1.6/schema.json"
 
     # Find all YAML files
     yaml_files = list(BASE_DIR.rglob("*.yaml")) + list(BASE_DIR.rglob("*.yml"))


### PR DESCRIPTION
## Summary
- Add WPM law stub for RVO with kvk-nummer parameter and eligible=false output
- Upgrade schema from v0.1.5 to v0.1.6 with new BUSINESS discoverable type for laws targeting business entities
- Update all existing law files to reference the new schema v0.1.6
- Update validation script to use the new schema version

## Changes
- **New WPM Law**: Created `law/wpm/WPM-2024-01-01.yaml` as a placeholder implementation
- **Schema Enhancement**: Added "BUSINESS" to the discoverable enum in `schema/v0.1.6/schema.json`
- **Global Update**: Updated all 25 law files to use the new schema version
- **Validation Update**: Updated `script/validate.py` to validate against v0.1.6

## Test plan
- [x] All schema validations pass successfully
- [x] Pre-commit hooks pass
- [x] WPM law validates as BUSINESS discoverable type
- [x] All existing laws continue to validate with updated schema

🤖 Generated with [Claude Code](https://claude.ai/code)