### PR TITLE
feat: Add feature flag for change wizard

### DIFF
--- a/web/feature_flags.py
+++ b/web/feature_flags.py
@@ -20,6 +20,7 @@ class FeatureFlags:
     DEFAULTS = {
         "WALLET": False,  # Wallet feature is disabled by default
         "CHAT": True,  # Chat feature is enabled by default
+        "CHANGE_WIZARD": False,  # Change wizard is disabled by default
     }
 
     @classmethod
@@ -142,3 +143,8 @@ def is_wallet_enabled() -> bool:
 def is_chat_enabled() -> bool:
     """Check if the chat feature is enabled."""
     return FeatureFlags.is_enabled("CHAT")
+
+
+def is_change_wizard_enabled() -> bool:
+    """Check if the change wizard feature is enabled."""
+    return FeatureFlags.is_enabled("CHANGE_WIZARD")

--- a/web/main.py
+++ b/web/main.py
@@ -17,7 +17,7 @@ from web.dependencies import (
     templates,
 )
 from web.engines import CaseManagerInterface, ClaimManagerInterface, EngineInterface
-from web.feature_flags import is_chat_enabled, is_wallet_enabled
+from web.feature_flags import is_change_wizard_enabled, is_chat_enabled, is_wallet_enabled
 from web.routers import admin, chat, edit, importer, laws, mcp, simulation, wallet
 
 app = FastAPI(title="Burger.nl")
@@ -130,6 +130,7 @@ async def root(
             "discoverable_service_laws": services.get_sorted_discoverable_service_laws(bsn),
             "wallet_enabled": is_wallet_enabled(),
             "chat_enabled": is_chat_enabled(),
+            "change_wizard_enabled": is_change_wizard_enabled(),
             "accepted_claims": accepted_claims,
         },
     )

--- a/web/templates/admin/partials/feature_flags.html
+++ b/web/templates/admin/partials/feature_flags.html
@@ -17,7 +17,7 @@
                 <div id="feature-loading-{{ name }}" class="htmx-indicator">
                     <div class="spinner w-6 h-6 border-2 border-t-2 border-gray-500 border-t-blue-500 rounded-full animate-spin"></div>
                 </div>
-                <label class="font-medium">{{ name|title }}</label>
+                <label class="font-medium">{{ name.replace('_', ' ')|title }}</label>
             </div>
         {% endfor %}
     </div>

--- a/web/templates/admin/partials/feature_flags.html
+++ b/web/templates/admin/partials/feature_flags.html
@@ -17,7 +17,7 @@
                 <div id="feature-loading-{{ name }}" class="htmx-indicator">
                     <div class="spinner w-6 h-6 border-2 border-t-2 border-gray-500 border-t-blue-500 rounded-full animate-spin"></div>
                 </div>
-                <label class="font-medium">{{ name.replace('_', ' ')|title }}</label>
+                <label class="font-medium">{{ name.replace('_', ' ') |title }}</label>
             </div>
         {% endfor %}
     </div>

--- a/web/templates/partials/dashboard.html
+++ b/web/templates/partials/dashboard.html
@@ -277,6 +277,7 @@
         {% endfor %}
     </div>
 </section>
+{% if change_wizard_enabled %}
 <!-- Wijziging doorgeven Wizard -->
 <style>
   .wizard-type-btn {
@@ -434,6 +435,7 @@
         </div>
     </div>
 </section>
+{% endif %}
 <!-- Info Section -->
 <section class="mt-12 grid md:grid-cols-2 gap-8">
     <div class="bg-blue-50 rounded-lg p-6">

--- a/web/templates/partials/dashboard.html
+++ b/web/templates/partials/dashboard.html
@@ -278,8 +278,8 @@
     </div>
 </section>
 {% if change_wizard_enabled %}
-<!-- Wijziging doorgeven Wizard -->
-<style>
+    <!-- Wijziging doorgeven Wizard -->
+    <style>
   .wizard-type-btn {
     display: flex;
     cursor: pointer;
@@ -354,87 +354,87 @@
     background-color: #ef4444;
     color: white;
   }
-</style>
-<section class="mb-8 bg-white rounded-lg shadow">
-    <div class="p-6">
-        <h3 class="font-semibold text-lg mb-4">Wijziging doorgeven</h3>
-        <p class="text-gray-600 mb-6">Geef hier wijzigingen door. Velden die niet gewijzigd zijn, kunt u leeg laten.</p>
-        <div id="wizard-container">
-            <!-- Step 0: Select type -->
-            <div id="step-0" class="wizard-step">
-                <h4 class="mb-2 block font-medium">Type wijziging</h4>
-                <div class="grid grid-cols-2 gap-4">
-                    <button type="button" class="wizard-type-btn" data-type="inkomen">
-                        <svg xmlns="http://www.w3.org/2000/svg"
-                             class="h-8 w-8 text-blue-600"
-                             fill="none"
-                             viewBox="0 0 24 24"
-                             stroke="currentColor">
-                            <ellipse cx="12" cy="6" rx="7" ry="3" stroke-width="2" stroke="currentColor" fill="none" />
-                            <path stroke-width="2" stroke="currentColor" fill="none" d="M5 6v6c0 1.66 3.13 3 7 3s7-1.34 7-3V6" />
-                            <path stroke-width="2" stroke="currentColor" fill="none" d="M5 12v6c0 1.66 3.13 3 7 3s7-1.34 7-3v-6" />
-                        </svg>
-                        <span class="font-medium">Inkomen</span>
-                    </button>
-                    <button type="button" class="wizard-type-btn" data-type="woonadres">
-                        <svg xmlns="http://www.w3.org/2000/svg"
-                             class="h-8 w-8 text-green-600"
-                             fill="none"
-                             viewBox="0 0 24 24"
-                             stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                        </svg>
-                        <span class="font-medium">Woonadres</span>
-                    </button>
-                    <button type="button" class="wizard-type-btn" data-type="huurprijs">
-                        <svg xmlns="http://www.w3.org/2000/svg"
-                             class="h-8 w-8 text-yellow-600"
-                             fill="none"
-                             viewBox="0 0 24 24"
-                             stroke="currentColor">
-                            <rect x="6" y="4" width="12" height="16" rx="2" stroke-width="2" stroke="currentColor" fill="none" />
-                            <path stroke-width="2" stroke="currentColor" fill="none" d="M9 8h6M9 12h6M9 16h2" />
-                        </svg>
-                        <span class="font-medium">Huurprijs</span>
-                    </button>
-                    <button type="button" class="wizard-type-btn" data-type="huishouden">
-                        <svg xmlns="http://www.w3.org/2000/svg"
-                             class="h-8 w-8 text-pink-600"
-                             fill="none"
-                             viewBox="0 0 24 24"
-                             stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                        </svg>
-                        <span class="font-medium">Gezin of huishouden</span>
-                    </button>
-                </div>
-            </div>
-            <!-- Wizard steps will be dynamically generated here -->
-            <div id="wizard-steps" class="hidden">
-                <form id="wizard-form" class="space-y-6">
-                    <div id="step-content" class="space-y-3"></div>
-                    <div id="step-navigation" class="flex justify-between">
-                        <button type="button"
-                                id="prev-btn"
-                                class="cursor-pointer rounded bg-gray-200 px-4 py-2 font-medium text-gray-700 hover:bg-gray-300 focus:outline-none">
-                            Terug
+    </style>
+    <section class="mb-8 bg-white rounded-lg shadow">
+        <div class="p-6">
+            <h3 class="font-semibold text-lg mb-4">Wijziging doorgeven</h3>
+            <p class="text-gray-600 mb-6">Geef hier wijzigingen door. Velden die niet gewijzigd zijn, kunt u leeg laten.</p>
+            <div id="wizard-container">
+                <!-- Step 0: Select type -->
+                <div id="step-0" class="wizard-step">
+                    <h4 class="mb-2 block font-medium">Type wijziging</h4>
+                    <div class="grid grid-cols-2 gap-4">
+                        <button type="button" class="wizard-type-btn" data-type="inkomen">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-blue-600"
+                                 fill="none"
+                                 viewBox="0 0 24 24"
+                                 stroke="currentColor">
+                                <ellipse cx="12" cy="6" rx="7" ry="3" stroke-width="2" stroke="currentColor" fill="none" />
+                                <path stroke-width="2" stroke="currentColor" fill="none" d="M5 6v6c0 1.66 3.13 3 7 3s7-1.34 7-3V6" />
+                                <path stroke-width="2" stroke="currentColor" fill="none" d="M5 12v6c0 1.66 3.13 3 7 3s7-1.34 7-3v-6" />
+                            </svg>
+                            <span class="font-medium">Inkomen</span>
                         </button>
-                        <button type="button"
-                                id="next-btn"
-                                class="cursor-pointer rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none">
-                            Volgende
+                        <button type="button" class="wizard-type-btn" data-type="woonadres">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-green-600"
+                                 fill="none"
+                                 viewBox="0 0 24 24"
+                                 stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                            </svg>
+                            <span class="font-medium">Woonadres</span>
                         </button>
-                        <button type="submit"
-                                id="submit-btn"
-                                class="cursor-pointer rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none hidden">
-                            Wijziging doorgeven
+                        <button type="button" class="wizard-type-btn" data-type="huurprijs">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-yellow-600"
+                                 fill="none"
+                                 viewBox="0 0 24 24"
+                                 stroke="currentColor">
+                                <rect x="6" y="4" width="12" height="16" rx="2" stroke-width="2" stroke="currentColor" fill="none" />
+                                <path stroke-width="2" stroke="currentColor" fill="none" d="M9 8h6M9 12h6M9 16h2" />
+                            </svg>
+                            <span class="font-medium">Huurprijs</span>
+                        </button>
+                        <button type="button" class="wizard-type-btn" data-type="huishouden">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-pink-600"
+                                 fill="none"
+                                 viewBox="0 0 24 24"
+                                 stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                            </svg>
+                            <span class="font-medium">Gezin of huishouden</span>
                         </button>
                     </div>
-                </form>
+                </div>
+                <!-- Wizard steps will be dynamically generated here -->
+                <div id="wizard-steps" class="hidden">
+                    <form id="wizard-form" class="space-y-6">
+                        <div id="step-content" class="space-y-3"></div>
+                        <div id="step-navigation" class="flex justify-between">
+                            <button type="button"
+                                    id="prev-btn"
+                                    class="cursor-pointer rounded bg-gray-200 px-4 py-2 font-medium text-gray-700 hover:bg-gray-300 focus:outline-none">
+                                Terug
+                            </button>
+                            <button type="button"
+                                    id="next-btn"
+                                    class="cursor-pointer rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none">
+                                Volgende
+                            </button>
+                            <button type="submit"
+                                    id="submit-btn"
+                                    class="cursor-pointer rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none hidden">
+                                Wijziging doorgeven
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
-    </div>
-</section>
+    </section>
 {% endif %}
 <!-- Info Section -->
 <section class="mt-12 grid md:grid-cols-2 gap-8">


### PR DESCRIPTION
## Summary

Adds a feature flag to control the visibility of the "Wijziging doorgeven" (Change Wizard) section on the burger.nl interface. The wizard allows users to report changes to their income, address, rent, or household composition.

## Changes

- ✅ Add `CHANGE_WIZARD` feature flag (disabled by default)
- ✅ Add `is_change_wizard_enabled()` convenience function
- ✅ Pass `change_wizard_enabled` to template context
- ✅ Wrap change wizard section with Jinja2 conditional
- ✅ Improve feature flag display formatting (e.g., "Change Wizard" instead of "Change_Wizard")

## Testing

1. Start the web interface: `uv run web/main.py`
2. Navigate to http://localhost:8000
3. Verify the "Wijziging doorgeven" section is **not visible** by default
4. Navigate to http://localhost:8000/admin/control
5. Enable the "Change Wizard" toggle
6. Return to http://localhost:8000
7. Verify the "Wijziging doorgeven" section is now visible

## Screenshots

The "Wijziging doorgeven" wizard section can now be controlled via the admin panel feature flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)