### PR TITLE
Change total income widget to display monthly amounts

### DIFF
--- a/web/templates/partials/dashboard_total_widget.html
+++ b/web/templates/partials/dashboard_total_widget.html
@@ -10,14 +10,12 @@
                     <div class="bg-white/20 rounded-lg p-2">
                         <svg xmlns="http://www.w3.org/2000/svg"
                              class="h-6 w-6 text-white"
-                             viewBox="0 0 24 24"
-                             fill="none"
-                             stroke="currentColor"
-                             stroke-width="2">
-                            <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+                             viewBox="0 0 20 20"
+                             fill="currentColor">
+                            <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
                         </svg>
                     </div>
-                    <h2 class="text-xl font-bold text-white">Uw totale inkomen en verplichtingen</h2>
+                    <h2 class="text-xl font-bold text-white">Uw financieel overzicht</h2>
                 </div>
                 <button @click="showBreakdown = !showBreakdown"
                         class="text-white/80 hover:text-white transition-colors cursor-pointer text-sm flex items-center space-x-1">
@@ -36,17 +34,17 @@
         <div class="p-8">
             <!-- Net Income Display -->
             <div class="text-center mb-6">
-                <div class="text-sm font-medium text-gray-600 mb-2">Netto inkomen per jaar</div>
-                {% if net_income_yearly_cents >= 0 %}
+                <div class="text-sm font-medium text-gray-600 mb-2">Netto resultaat per maand</div>
+                {% if net_income_monthly_cents >= 0 %}
                     <div class="text-6xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-green-500 mb-2 animate-fade-in">
-                        {{ (net_income_yearly_cents / 100) | format_currency }}
+                        {{ (net_income_monthly_cents / 100) | format_currency }}
                     </div>
                 {% else %}
                     <div class="text-6xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-600 to-orange-500 mb-2 animate-fade-in">
-                        {{ (net_income_yearly_cents / 100) | format_currency }}
+                        {{ (net_income_monthly_cents / 100) | format_currency }}
                     </div>
                 {% endif %}
-                <div class="text-lg text-gray-500">(ongeveer {{ (net_income_monthly_cents / 100) | format_currency }} per maand)</div>
+                <div class="text-lg text-gray-500">(ongeveer {{ (net_income_yearly_cents / 100) | format_currency }} per jaar)</div>
             </div>
             <!-- Visual Bar Chart -->
             <div class="mb-6">
@@ -55,12 +53,12 @@
                         <div class="w-3 h-3 bg-green-500 rounded-full"></div>
                         <span class="text-sm font-medium text-gray-700">Toeslagen & Uitkeringen</span>
                     </div>
-                    <span class="text-sm font-bold text-green-600">{{ (total_benefits_yearly_cents / 100) | format_currency }}</span>
+                    <span class="text-sm font-bold text-green-600">{{ (total_benefits_monthly_cents / 100) | format_currency }} /mnd</span>
                 </div>
                 <div class="relative h-4 bg-gray-200 rounded-full overflow-hidden mb-4">
-                    {% set total = total_benefits_yearly_cents + total_taxes_yearly_cents %}
+                    {% set total = total_benefits_monthly_cents + total_taxes_monthly_cents %}
                     {% if total > 0 %}
-                        {% set benefits_percentage = (total_benefits_yearly_cents / total * 100)|int %}
+                        {% set benefits_percentage = (total_benefits_monthly_cents / total * 100)|int %}
                         <div class="absolute top-0 left-0 h-full bg-gradient-to-r from-green-500 to-emerald-500 transition-all duration-1000 ease-out"
                              style="width: {{ benefits_percentage }}%"></div>
                     {% endif %}
@@ -70,11 +68,11 @@
                         <div class="w-3 h-3 bg-blue-500 rounded-full"></div>
                         <span class="text-sm font-medium text-gray-700">Belastingen</span>
                     </div>
-                    <span class="text-sm font-bold text-blue-600">{{ (total_taxes_yearly_cents / 100) | format_currency }}</span>
+                    <span class="text-sm font-bold text-blue-600">{{ (total_taxes_monthly_cents / 100) | format_currency }} /mnd</span>
                 </div>
                 <div class="relative h-4 bg-gray-200 rounded-full overflow-hidden">
                     {% if total > 0 %}
-                        {% set taxes_percentage = (total_taxes_yearly_cents / total * 100)|int %}
+                        {% set taxes_percentage = (total_taxes_monthly_cents / total * 100)|int %}
                         <div class="absolute top-0 left-0 h-full bg-gradient-to-r from-blue-500 to-indigo-500 transition-all duration-1000 ease-out"
                              style="width: {{ taxes_percentage }}%"></div>
                     {% endif %}
@@ -84,10 +82,10 @@
             <div class="grid grid-cols-2 gap-4">
                 <div class="bg-white rounded-lg p-4 border border-gray-200">
                     <div class="text-sm text-gray-600 mb-1">Totaal ontvangen</div>
-                    <div class="text-2xl font-bold text-green-600">{{ (total_benefits_yearly_cents / 100) | format_currency }}</div>
+                    <div class="text-2xl font-bold text-green-600">{{ (total_benefits_monthly_cents / 100) | format_currency }}</div>
                     <div class="text-xs text-gray-500 mt-1">
                         {% if benefits|length > 0 %}
-                            {{ benefits|length }} {{ 'regelingen' if benefits|length != 1 else 'regeling' }}
+                            {{ benefits|length }} {{ 'regelingen' if benefits|length != 1 else 'regeling' }} (per maand)
                         {% else %}
                             Geen regelingen
                         {% endif %}
@@ -95,8 +93,8 @@
                 </div>
                 <div class="bg-white rounded-lg p-4 border border-gray-200">
                     <div class="text-sm text-gray-600 mb-1">Totaal verschuldigd</div>
-                    <div class="text-2xl font-bold text-blue-600">{{ (total_taxes_yearly_cents / 100) | format_currency }}</div>
-                    <div class="text-xs text-gray-500 mt-1">Belastingen</div>
+                    <div class="text-2xl font-bold text-blue-600">{{ (total_taxes_monthly_cents / 100) | format_currency }}</div>
+                    <div class="text-xs text-gray-500 mt-1">Belastingen (per maand)</div>
                 </div>
             </div>
         </div>
@@ -130,15 +128,15 @@
                                         <div class="font-medium text-gray-900">{{ benefit.name }}</div>
                                         <div class="text-xs text-gray-600">
                                             {% if benefit.per_month %}
-                                                {{ (benefit.amount_cents / 100) | format_currency }} per maand
+                                                {{ (benefit.amount_cents / 100) | format_currency }} per maand ({{ (benefit.yearly_amount_cents / 100) | format_currency }} per jaar)
                                             {% else %}
                                                 {{ (benefit.amount_cents / 100) | format_currency }} per jaar
                                             {% endif %}
                                         </div>
                                     </div>
                                     <div class="text-right">
-                                        <div class="font-bold text-green-700">{{ (benefit.yearly_amount_cents / 100) | format_currency }}</div>
-                                        <div class="text-xs text-gray-500">per jaar</div>
+                                        <div class="font-bold text-green-700">{{ (benefit.yearly_amount_cents / 12 / 100) | format_currency }}</div>
+                                        <div class="text-xs text-gray-500">per maand</div>
                                     </div>
                                 </div>
                             {% endfor %}
@@ -146,8 +144,9 @@
                         <div class="mt-4 pt-4 border-t border-green-200">
                             <div class="flex justify-between items-center">
                                 <span class="font-semibold text-gray-900">Totaal ontvangen</span>
-                                <span class="text-xl font-bold text-green-700">{{ (total_benefits_yearly_cents / 100) | format_currency }}</span>
+                                <span class="text-xl font-bold text-green-700">{{ (total_benefits_monthly_cents / 100) | format_currency }}</span>
                             </div>
+                            <div class="text-xs text-gray-500 text-right mt-1">per maand</div>
                         </div>
                     {% else %}
                         <p class="text-gray-500 text-sm">Geen toeslagen of uitkeringen</p>
@@ -172,15 +171,15 @@
                                         <div class="font-medium text-gray-900">{{ tax.name }}</div>
                                         <div class="text-xs text-gray-600">
                                             {% if tax.per_month %}
-                                                {{ (tax.amount_cents / 100) | format_currency }} per maand
+                                                {{ (tax.amount_cents / 100) | format_currency }} per maand ({{ (tax.yearly_amount_cents / 100) | format_currency }} per jaar)
                                             {% else %}
                                                 {{ (tax.amount_cents / 100) | format_currency }} per jaar
                                             {% endif %}
                                         </div>
                                     </div>
                                     <div class="text-right">
-                                        <div class="font-bold text-blue-700">{{ (tax.yearly_amount_cents / 100) | format_currency }}</div>
-                                        <div class="text-xs text-gray-500">per jaar</div>
+                                        <div class="font-bold text-blue-700">{{ (tax.yearly_amount_cents / 12 / 100) | format_currency }}</div>
+                                        <div class="text-xs text-gray-500">per maand</div>
                                     </div>
                                 </div>
                             {% endfor %}
@@ -188,8 +187,9 @@
                         <div class="mt-4 pt-4 border-t border-blue-200">
                             <div class="flex justify-between items-center">
                                 <span class="font-semibold text-gray-900">Totaal verschuldigd</span>
-                                <span class="text-xl font-bold text-blue-700">{{ (total_taxes_yearly_cents / 100) | format_currency }}</span>
+                                <span class="text-xl font-bold text-blue-700">{{ (total_taxes_monthly_cents / 100) | format_currency }}</span>
                             </div>
+                            <div class="text-xs text-gray-500 text-right mt-1">per maand</div>
                         </div>
                     {% else %}
                         <p class="text-gray-500 text-sm">Geen belastingen</p>
@@ -198,16 +198,16 @@
             </div>
             <!-- Net Total -->
             <div class="mt-6 pt-6 border-t-2 border-gray-300">
-                <div class="flex items-center justify-between p-4 bg-gradient-to-r {% if net_income_yearly_cents >= 0 %}from-emerald-50 to-green-50 border-emerald-200{% else %}from-amber-50 to-orange-50 border-amber-200{% endif %} rounded-lg border-2">
+                <div class="flex items-center justify-between p-4 bg-gradient-to-r {% if net_income_monthly_cents >= 0 %}from-emerald-50 to-green-50 border-emerald-200{% else %}from-amber-50 to-orange-50 border-amber-200{% endif %} rounded-lg border-2">
                     <div>
-                        <div class="text-sm font-medium text-gray-600">Netto inkomen (toeslagen - belastingen)</div>
+                        <div class="text-sm font-medium text-gray-600">Netto resultaat (toeslagen - belastingen)</div>
                         <div class="text-xs text-gray-500 mt-1">Na aftrek van alle belastingen en inclusief alle toeslagen</div>
                     </div>
                     <div class="text-right">
-                        <div class="text-3xl font-bold {% if net_income_yearly_cents >= 0 %}text-emerald-700{% else %}text-amber-700{% endif %}">
-                            {{ (net_income_yearly_cents / 100) | format_currency }}
+                        <div class="text-3xl font-bold {% if net_income_monthly_cents >= 0 %}text-emerald-700{% else %}text-amber-700{% endif %}">
+                            {{ (net_income_monthly_cents / 100) | format_currency }}
                         </div>
-                        <div class="text-sm text-gray-600 mt-1">per jaar</div>
+                        <div class="text-sm text-gray-600 mt-1">per maand</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Changed the total income dashboard widget to display monthly amounts as the primary view instead of yearly amounts
- Updated terminology from "netto inkomen" to "netto resultaat" for clarity (it represents net effect of benefits minus taxes, not earned income)
- Replaced dollar sign icon with chart-bar icon from Heroicons (more appropriate for Dutch government context)

## Changes
- **Main display**: Shows "Netto resultaat per maand" with yearly amount as secondary info in parentheses
- **Bar chart labels**: Updated to show monthly amounts with "/mnd" suffix
- **Quick stats cards**: Display monthly totals with "(per maand)" clarification
- **Detailed breakdown**: Individual benefit/tax items show monthly amounts prominently
- **Icon**: Changed from dollar sign to chart-bar icon (consistent with existing Heroicons usage)
- **Terminology**: "Netto inkomen" → "Netto resultaat" throughout the widget

## Technical Details
- Only template changes required; backend already calculated both monthly and yearly amounts
- Feature remains behind `TOTAL_INCOME_WIDGET` feature flag (currently disabled by default)

## Test plan
- [ ] Enable the feature flag: `TOTAL_INCOME_WIDGET=true`
- [ ] Navigate to a citizen dashboard
- [ ] Verify the widget shows monthly amounts prominently
- [ ] Verify yearly amounts are shown as secondary info
- [ ] Check that the chart-bar icon displays correctly
- [ ] Expand the detailed breakdown and verify monthly/yearly amounts are correct