### PR TITLE
Fix typo in approved status message

### DIFF
--- a/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM.html
+++ b/web/templates/partials/tiles/law/participatiewet/bijstand/GEMEENTE_AMSTERDAM.html
@@ -34,7 +34,7 @@
 {% endblock %}
 {% block approved_status %}
     <p class="text-sm text-green-600 text-center">
-        Uw aanvraag is goedgekeurd, uw bijstaand zal maandelijks worden uitgekeerd.
+        Uw aanvraag is goedgekeurd, uw bijstand zal maandelijks worden uitgekeerd.
     </p>
 {% endblock %}
 {% block not_eligible_questions %}


### PR DESCRIPTION
Typo spotted and described in this
[linkedin post](https://www.linkedin.com/feed/update/urn:li:activity:7387497250878562304?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7387497250878562304%2C7387730668178395136%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287387730668178395136%2Curn%3Ali%3Aactivity%3A7387497250878562304%29). 