### PR TITLE
Update links to laws in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,47 +98,47 @@ Vooralsnog zijn deze wetten geïmplementeerd in `machine law` (met behulp van ee
 
 ### Zorgtoeslag
 
-- [Hoofdwet](law/zorgtoeslagwet/TOESLAGEN-2025-01-01.yaml) - Berekening zorgtoeslag
-- [Verzekeringsstatus](law/zvw/RVZ-2024-01-01.yaml) - Bepaling verzekeringsstatus
+- [Hoofdwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/zorgtoeslagwet/TOESLAGEN-2025-01-01.yaml) - Berekening zorgtoeslag
+- [Verzekeringsstatus](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/zvw/RVZ-2024-01-01.yaml) - Bepaling verzekeringsstatus
 
 ### AOW
 
-- [Hoofdwet](law/algemene_ouderdomswet/SVB-2024-01-01.yaml) - Berekening AOW-uitkering
-- [Leeftijdsbepaling](law/algemene_ouderdomswet/leeftijdsbepaling/SVB-2024-01-01.yaml) - Bepaling AOW-leeftijd
+- [Hoofdwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/algemene_ouderdomswet/SVB-2024-01-01.yaml) - Berekening AOW-uitkering
+- [Leeftijdsbepaling](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/algemene_ouderdomswet/leeftijdsbepaling/SVB-2024-01-01.yaml) - Bepaling AOW-leeftijd
 
 ### Huurtoeslag
 
-- [Hoofdwet](law/wet_op_de_huurtoeslag/TOESLAGEN-2025-01-01.yaml) - Berekening huurtoeslag
+- [Hoofdwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_op_de_huurtoeslag/TOESLAGEN-2025-01-01.yaml) - Berekening huurtoeslag
 
 ### Participatiewet (Bijstand)
 
-- [Landelijke regels](law/participatiewet/bijstand/SZW-2023-01-01.yaml) - Beoordeling bijstandsrecht (SZW)
-- [Gemeente Amsterdam](law/participatiewet/bijstand/gemeenten/GEMEENTE_AMSTERDAM-2023-01-01.yaml) - Lokale bijstandsregels
+- [Landelijke regels](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/participatiewet/bijstand/SZW-2023-01-01.yaml) - Beoordeling bijstandsrecht (SZW)
+- [Gemeente Amsterdam](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/participatiewet/bijstand/gemeenten/GEMEENTE_AMSTERDAM-2023-01-01.yaml) - Lokale bijstandsregels
 
 ### Bestuursrecht (AWB)
 
-- [Bezwaarprocedure](law/awb/bezwaar/JenV-2024-01-01.yaml) - Regels voor bezwaar
-- [Beroepsprocedure](law/awb/beroep/JenV-2024-01-01.yaml) - Regels voor beroep
+- [Bezwaarprocedure](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/awb/bezwaar/JenV-2024-01-01.yaml) - Regels voor bezwaar
+- [Beroepsprocedure](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/awb/beroep/JenV-2024-01-01.yaml) - Regels voor beroep
 
 ### Kieswet
 
-- [Hoofdwet](law/kieswet/KIESRAAD-2024-01-01.yaml) - Bepaling kiesrecht
+- [Hoofdwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/kieswet/KIESRAAD-2024-01-01.yaml) - Bepaling kiesrecht
 
 ### Overige Wetten
 
-- [Handelsregisterwet](law/handelsregisterwet/KVK-2024-01-01.yaml) - KVK-registratie
-- [Vreemdelingenwet](law/vreemdelingenwet/IND-2024-01-01.yaml) - Verblijfsvergunningen
-- [Penitentiaire Beginselenwet](law/penitentiaire_beginselenwet/DJI-2022-01-01.yaml) - Detentieregels
-- [Wet Forensische Zorg](law/wet_forensische_zorg/DJI-2022-01-01.yaml) - Forensische zorg
-- [Wet Studiefinanciering](law/wet_studiefinanciering/DUO-2024-01-01.yaml) - Studiefinanciering
-- [Wetboek van Strafrecht](law/wetboek_van_strafrecht/JUSTID-2023-01-01.yaml) - Strafbepalingen
+- [Handelsregisterwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/handelsregisterwet/KVK-2024-01-01.yaml) - KVK-registratie
+- [Vreemdelingenwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/vreemdelingenwet/IND-2024-01-01.yaml) - Verblijfsvergunningen
+- [Penitentiaire Beginselenwet](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/penitentiaire_beginselenwet/DJI-2022-01-01.yaml) - Detentieregels
+- [Wet Forensische Zorg](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_forensische_zorg/DJI-2022-01-01.yaml) - Forensische zorg
+- [Wet Studiefinanciering](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_studiefinanciering/DUO-2024-01-01.yaml) - Studiefinanciering
+- [Wetboek van Strafrecht](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wetboek_van_strafrecht/JUSTID-2023-01-01.yaml) - Strafbepalingen
 
 ### Ondersteunende Wetten
 
-- [Wet BRP](law/wet_brp/RvIG-2020-01-01.yaml) - Persoonsgegevens
-- [Wet Inkomstenbelasting](law/wet_inkomstenbelasting/UWV-2020-01-01.yaml) - Toetsingsinkomen
-- [SUWI](law/wet_structuur_uitvoeringsorganisatie_werk_en_inkomen/UWV-2024-01-01.yaml) - Verzekerde jaren
-- [CBS](law/wet_op_het_centraal_bureau_voor_de_statistiek/CBS-2024-01-01.yaml) - Levensverwachting
+- [Wet BRP](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_brp/RvIG-2020-01-01.yaml) - Persoonsgegevens
+- [Wet Inkomstenbelasting](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_inkomstenbelasting/UWV-2020-01-01.yaml) - Toetsingsinkomen
+- [SUWI](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_structuur_uitvoeringsorganisatie_werk_en_inkomen/UWV-2024-01-01.yaml) - Verzekerde jaren
+- [CBS](https://github.com/MinBZK/regelrecht-laws/tree/main/laws/wet_op_het_centraal_bureau_voor_de_statistiek/CBS-2024-01-01.yaml) - Levensverwachting
 
 ## 🚀 Aan de slag
 


### PR DESCRIPTION
fixes the issue that the links to laws (in another repo) are all a 404:

<img width="947" height="645" alt="Scherm­afbeelding 2025-10-25 om 10 04 36" src="https://github.com/user-attachments/assets/4322a150-3058-406f-8519-28cd80e00c42" />
<img width="1387" height="618" alt="Scherm­afbeelding 2025-10-25 om 10 04 24" src="https://github.com/user-attachments/assets/6af4fe3c-046d-4bb1-8266-c385772a9086" />

feel free to implement a more sustainable solution and close this PR. Or merge if you need this quick fix.