### PR TITLE
feat: distinguish bevoegdheid, machtiging, and vertegenwoordiging van rechtswege

### DIFF
--- a/data/profiles.yaml
+++ b/data/profiles.yaml
@@ -3377,11 +3377,12 @@ profiles:
   # Profile: Curator who manages a curandus
   '400100001':
     name: Geert de Vries
-    description: Professioneel curator, bewindvoerder en mentor voor meerdere cliënten
+    description: Professioneel curator, bewindvoerder en mentor voor meerdere cliënten, tevens gevolmachtigde
     properties:
       - Curator
       - Bewindvoerder
       - Mentor
+      - Gevolmachtigde
     sources:
       CBS: *id001
       KIESRAAD: *id002
@@ -3399,6 +3400,17 @@ profiles:
           residence_address: Lange Nieuwstraat 10, 3512PH Utrecht
           has_fixed_address: true
           household_size: 1
+      NOTARIAAT:
+        # Volmacht registratie - Geert heeft algemene volmacht van zijn buurvrouw
+        volmacht_registraties:
+        - bsn_gevolmachtigde: '400100001'
+          bsn_volmachtgever: '500000010'
+          naam_volmachtgever: Maria de Jong
+          volmacht_type: ALGEMENE_VOLMACHT
+          datum_ingang: '2022-09-01'
+          datum_einde: null
+          status: ACTIEF
+          is_herroepen: false
       RECHTSPRAAK:
         # Curatele registraties - Geert is curator voor Sophie
         curatele_registraties:

--- a/laws/burgerlijk_wetboek_beschermingsbewind/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_beschermingsbewind/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 970f63e4-eed1-4884-a1ee-9050733eb2e1
 name: Bepalen beschermingsbewind en vertegenwoordigingsbevoegdheid bewindvoerder
 law: burgerlijk_wetboek_beschermingsbewind
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_curatele/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_curatele/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: b270d49d-f98d-4f3a-bff7-1043dbd5dacb
 name: Bepalen curatele en vertegenwoordigingsbevoegdheid curator
 law: burgerlijk_wetboek_curatele
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_executeur/NOTARIAAT-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_executeur/NOTARIAAT-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 9e69492c-c73d-44ea-9672-8a1d36f53ad5
 name: Bepalen executeurschap en vertegenwoordigingsbevoegdheid executeur
 law: burgerlijk_wetboek_executeur
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "NOTARIAAT"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 4"
   bwb_id: "BWBR0002761"

--- a/laws/burgerlijk_wetboek_gezag/RvIG-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_gezag/RvIG-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: a87bbb48-0bde-487a-af4d-3dc7f4a7c220
 name: Bepalen vertegenwoordigingsbevoegdheid minderjarigen
 law: burgerlijk_wetboek_gezag
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RvIG"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "BEVOEGDHEID"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_handelingsonbekwaamheid/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_handelingsonbekwaamheid/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 9f2a3b4c-1d5e-4f6a-b7c8-2e3d4f5a6b7c
 name: Bepalen handelingsonbekwaamheid volwassenen
 law: burgerlijk_wetboek_handelingsonbekwaamheid
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_mentorschap/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_mentorschap/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 0c6a4f3c-8a49-4f76-a109-265c0b7a05dc
 name: Bepalen mentorschap en vertegenwoordigingsbevoegdheid mentor
 law: burgerlijk_wetboek_mentorschap
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_minderjarigheid/RvIG-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_minderjarigheid/RvIG-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 848e8af1-5b25-454d-9813-8d295a93fd44
 name: Bepalen handelingsbekwaamheid minderjarigen
 law: burgerlijk_wetboek_minderjarigheid
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RvIG"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "BEVOEGDHEID"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 1"
   bwb_id: "BWBR0002656"

--- a/laws/burgerlijk_wetboek_volmacht/NOTARIAAT-2024-01-01.yaml
+++ b/laws/burgerlijk_wetboek_volmacht/NOTARIAAT-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 5a437c98-30bb-4044-af1a-11701a9bf7ea
 name: Bepalen volmacht en vertegenwoordigingsbevoegdheid gevolmachtigde
 law: burgerlijk_wetboek_volmacht
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "NOTARIAAT"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "MACHTIGING"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 3"
   bwb_id: "BWBR0005291"

--- a/laws/faillissementswet_curator/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/faillissementswet_curator/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: e1199fc0-2fbc-4bc7-aab5-e4f3790a5cc7
 name: Bepalen faillissementscurator en vertegenwoordigingsbevoegdheid curator boedel
 law: faillissementswet_curator
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Faillissementswet"
   bwb_id: "BWBR0001860"

--- a/laws/faillissementswet_wsnp_bewindvoerder/RECHTSPRAAK-2024-01-01.yaml
+++ b/laws/faillissementswet_wsnp_bewindvoerder/RECHTSPRAAK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 1a8ce7cd-8c96-41ae-806c-d6387e43c0dd
 name: Bepalen WSNP-bewindvoerder en vertegenwoordigingsbevoegdheid schuldsanering
 law: faillissementswet_wsnp_bewindvoerder
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RECHTSPRAAK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Faillissementswet"
   bwb_id: "BWBR0001860"

--- a/laws/machtigingenwet/KVK-2024-01-01.yaml
+++ b/laws/machtigingenwet/KVK-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 3f8a2b1c-9d4e-4f5a-b8c7-6e1d2f3a4b5c
 name: Bepalen vertegenwoordigingsbevoegdheid namens rechtspersonen
 law: machtigingenwet
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "KVK"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "BEVOEGDHEID"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 2"
   bwb_id: "BWBR0003045"

--- a/laws/wgbo_vertegenwoordiger/RvIG-2024-01-01.yaml
+++ b/laws/wgbo_vertegenwoordiger/RvIG-2024-01-01.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json
 uuid: 54ba9cdb-61ff-4735-a650-8ccee6ef0bb8
 name: Bepalen WGBO-vertegenwoordiger voor wilsonbekwame patienten
 law: wgbo_vertegenwoordiger
@@ -7,7 +7,8 @@ legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
 valid_from: 2024-01-01
 service: "RvIG"
-discoverable: "DELEGATION_PROVIDER"
+discoverable: "REPRESENTATION_PROVIDER"
+legal_category: "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
 legal_basis:
   law: "Burgerlijk Wetboek Boek 7"
   bwb_id: "BWBR0005290"

--- a/machine/delegation/manager.py
+++ b/machine/delegation/manager.py
@@ -3,7 +3,7 @@
 This module provides the DelegationManager class which determines what entities
 a user can act on behalf of by evaluating delegation provider laws via the RulesEngine.
 
-The DelegationManager discovers and evaluates all laws with discoverable: "DELEGATION_PROVIDER"
+The DelegationManager discovers and evaluates all laws with discoverable: "REPRESENTATION_PROVIDER"
 and uses a standard interface to parse the results into Delegation objects.
 """
 
@@ -48,7 +48,7 @@ class DelegationManager:
     def get_delegations_for_user(self, bsn: str, reference_date: date | None = None) -> list[Delegation]:
         """Get all delegations available for a user.
 
-        This method discovers all DELEGATION_PROVIDER laws and evaluates each one
+        This method discovers all REPRESENTATION_PROVIDER laws and evaluates each one
         to find all entities the user can act on behalf of. This includes:
         - SELF delegation (from minderjarigheid law) representing the user acting as themselves
         - BUSINESS delegations (from machtigingenwet) for businesses the user can represent
@@ -67,7 +67,7 @@ class DelegationManager:
         delegations: list[Delegation] = []
 
         # Discover and evaluate all delegation provider laws
-        delegation_laws = self.services.get_discoverable_service_laws("DELEGATION_PROVIDER")
+        delegation_laws = self.services.get_discoverable_service_laws("REPRESENTATION_PROVIDER")
 
         for service, laws in delegation_laws.items():
             for law in laws:
@@ -105,6 +105,7 @@ class DelegationManager:
                 subject_type="SELF",
                 subject_name="Mezelf",
                 delegation_type="EIGEN_ZAKEN",
+                legal_category="BEVOEGDHEID",
                 permissions=ordered_permissions,
                 valid_from=None,
                 valid_until=None,
@@ -135,6 +136,13 @@ class DelegationManager:
         """
         delegations: list[Delegation] = []
 
+        # Look up legal_category from the RuleSpec
+        try:
+            rule_spec = self.services.resolver.find_rule(law, reference_date.strftime("%Y-%m-%d"), service)
+            legal_category = rule_spec.legal_category if rule_spec else ""
+        except Exception:
+            legal_category = ""
+
         try:
             result = self.services.evaluate(
                 service=service,
@@ -164,6 +172,7 @@ class DelegationManager:
                     subject_type=subject_types[i],
                     subject_name=subject_names[i],
                     delegation_type=delegation_types[i],
+                    legal_category=legal_category,
                     permissions=list(permissions[i]) if permissions[i] else [],
                     valid_from=self._parse_date(valid_from_dates[i]),
                     valid_until=self._parse_date(valid_until_dates[i]),
@@ -298,6 +307,7 @@ class DelegationManager:
                     subject_type=delegation.subject_type,
                     subject_name=delegation.subject_name,
                     delegation_type=delegation.delegation_type,
+                    legal_category=delegation.legal_category,
                     permissions=delegation.permissions,
                 )
 

--- a/machine/delegation/models.py
+++ b/machine/delegation/models.py
@@ -21,6 +21,7 @@ class Delegation:
         subject_type: Whether the subject is a citizen or business
         subject_name: Human-readable name of the subject (company or person name)
         delegation_type: The type of delegation (e.g., EIGENAAR, BESTUURDER)
+        legal_category: Legal category (BEVOEGDHEID, MACHTIGING, VERTEGENWOORDIGING_VAN_RECHTSWEGE)
         permissions: List of permissions granted (e.g., LEZEN, CLAIMS_INDIENEN)
         valid_from: Date from which the delegation is valid
         valid_until: Optional end date for the delegation
@@ -30,6 +31,7 @@ class Delegation:
     subject_type: Literal["CITIZEN", "BUSINESS"]
     subject_name: str
     delegation_type: str
+    legal_category: str
     permissions: list[str]
     valid_from: date
     valid_until: date | None = None
@@ -65,6 +67,7 @@ class DelegationContext:
         subject_type: Whether the subject is a citizen or business
         subject_name: Human-readable name for display in UI
         delegation_type: The type of delegation (e.g., EIGENAAR, BESTUURDER)
+        legal_category: Legal category (BEVOEGDHEID, MACHTIGING, VERTEGENWOORDIGING_VAN_RECHTSWEGE)
         permissions: List of permissions the actor has
     """
 
@@ -73,6 +76,7 @@ class DelegationContext:
     subject_type: Literal["CITIZEN", "BUSINESS"]
     subject_name: str
     delegation_type: str
+    legal_category: str
     permissions: list[str]
 
     def can_read(self) -> bool:
@@ -95,6 +99,7 @@ class DelegationContext:
             "subject_type": self.subject_type,
             "subject_name": self.subject_name,
             "delegation_type": self.delegation_type,
+            "legal_category": self.legal_category,
             "permissions": self.permissions,
         }
 
@@ -114,5 +119,6 @@ class DelegationContext:
             subject_type=data["subject_type"],
             subject_name=data["subject_name"],
             delegation_type=data["delegation_type"],
+            legal_category=data.get("legal_category", ""),
             permissions=data["permissions"],
         )

--- a/machine/utils.py
+++ b/machine/utils.py
@@ -43,6 +43,7 @@ class RuleSpec:
     valid_from: datetime
     service: str
     discoverable: str
+    legal_category: str
     properties: dict[str, Any]
 
     @classmethod
@@ -59,6 +60,7 @@ class RuleSpec:
             name=data.get("name", ""),
             law=data.get("law", ""),
             discoverable=data.get("discoverable", ""),
+            legal_category=data.get("legal_category", ""),
             valid_from=data.get("valid_from")
             if isinstance(data.get("valid_from"), datetime)
             else datetime.combine(data.get("valid_from"), datetime.min.time()),
@@ -157,6 +159,7 @@ class RuleResolver:
                 "valid_from": rule.valid_from,
                 "service": rule.service,
                 "discoverable": rule.discoverable,
+                "legal_category": rule.legal_category,
                 **{f"prop_{k}": v for k, v in rule.properties.items()},
             }
             for rule in self.rules

--- a/machinev2/machine/ruleresolver/rulespec.go
+++ b/machinev2/machine/ruleresolver/rulespec.go
@@ -18,6 +18,7 @@ type RuleSpec struct {
 	LegalCharacter *string       `yaml:"legal_character,omitempty"`
 	DecisionType   *string       `yaml:"decision_type,omitempty"`
 	Discoverable   *string       `yaml:"discoverable,omitempty"`
+	LegalCategory  *string       `yaml:"legal_category,omitempty"`
 	ValidFrom      time.Time     `yaml:"valid_from"`
 	Service        string        `yaml:"service"`
 	Description    string        `yaml:"description"`

--- a/schema/v0.1.8/schema.json
+++ b/schema/v0.1.8/schema.json
@@ -1,0 +1,804 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.8/schema.json",
+    "title": "Dutch Government Service Definition",
+    "type": "object",
+    "required": [
+      "uuid",
+      "name",
+      "law",
+      "valid_from",
+      "service",
+      "description",
+      "properties"
+    ],
+    "properties": {
+      "uuid": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "name": {
+        "type": "string"
+      },
+      "law": {
+        "type": "string"
+      },
+      "law_type": {
+        "type": "string",
+        "enum": [
+          "FORMELE_WET",
+          "GEMEENTELIJKE_VERORDENING"
+        ]
+      },
+      "legal_character": {
+        "type": "string",
+        "enum": [
+          "BESCHIKKING",
+          "BESLUIT_VAN_ALGEMENE_STREKKING"
+        ]
+      },
+      "decision_type": {
+        "type": "string",
+        "enum": [
+          "TOEKENNING",
+          "ALGEMEEN_VERBINDEND_VOORSCHRIFT",
+          "BELEIDSREGEL",
+          "VOORBEREIDINGSBESLUIT",
+          "ANDERE_HANDELING",
+          "AANSLAG"
+        ]
+      },
+      "discoverable": {
+        "type": "string",
+        "enum": [
+          "CITIZEN",
+          "BUSINESS",
+          "REPRESENTATION_PROVIDER",
+          "HIDDEN"
+        ]
+      },
+      "legal_category": {
+        "type": "string",
+        "enum": [
+          "BEVOEGDHEID",
+          "MACHTIGING",
+          "VERTEGENWOORDIGING_VAN_RECHTSWEGE"
+        ],
+        "description": "Juridische categorie van de vertegenwoordigingsrelatie"
+      },
+      "requires_manual_approval": {
+        "type": "boolean",
+        "default": false,
+        "description": "Geeft aan of deze wet handmatige goedkeuring door een medewerker vereist voordat een aanvraag wordt toegekend"
+      },
+      "valid_from": {
+        "type": "string",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      },
+      "service": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "references": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "law",
+            "article",
+            "url"
+          ],
+          "properties": {
+            "law": {
+              "type": "string"
+            },
+            "article": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "legal_basis": {
+        "$ref": "#/definitions/legalBasis"
+      },
+      "properties": {
+        "type": "object",
+        "properties": {
+          "parameters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/parameterField"
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/sourceField"
+            }
+          },
+          "input": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/inputField"
+            }
+          },
+          "output": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/outputField"
+            }
+          },
+          "definitions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "definitions": {
+      "baseField": {
+        "type": "object",
+        "required": [
+          "name",
+          "description",
+          "type"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "amount",
+              "object",
+              "array",
+              "date",
+              "time",
+              "enum"
+            ]
+          },
+          "type_spec": {
+            "type": "object",
+            "properties": {
+              "unit": {
+                "type": "string",
+                "enum": [
+                  "eurocent",
+                  "years",
+                  "weeks",
+                  "months"
+                ]
+              },
+              "precision": {
+                "type": "number",
+                "minimum": 0
+              },
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              }
+            }
+          },
+          "temporal": {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "period",
+                  "point_in_time"
+                ]
+              },
+              "period_type": {
+                "type": "string",
+                "enum": [
+                  "year",
+                  "month",
+                  "continuous"
+                ]
+              },
+              "reference": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "$calculation_date",
+                      "$prev_january_first",
+                      "$january_first"
+                    ]
+                  },
+                  {
+                    "$ref": "#/definitions/variableReference"
+                  }
+                ]
+              },
+              "immutable_after": {
+                "type": "string",
+                "pattern": "^P[0-9]+[YMD]$"
+              }
+            }
+          },
+          "legal_basis": {
+            "$ref": "#/definitions/legalBasis"
+          }
+        }
+      },
+      "variableReference": {
+        "type": "string",
+        "pattern": "^\\$[A-Z_][A-Z0-9_]*(?:\\.[A-Z_][A-Z0-9_]*)*$"
+      },
+      "parameterField": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/baseField"
+          },
+          {
+            "properties": {
+              "required": {
+                "type": "boolean"
+              }
+            }
+          }
+        ]
+      },
+      "sourceField": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/baseField"
+          },
+          {
+            "properties": {
+              "source_reference": {
+                "$ref": "#/definitions/sourceReference"
+              },
+              "service_reference": {
+                "$ref": "#/definitions/serviceReference"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "source_reference"
+                ]
+              },
+              {
+                "required": [
+                  "service_reference"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "inputField": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/baseField"
+          },
+          {
+            "properties": {
+              "service_reference": {
+                "$ref": "#/definitions/serviceReference"
+              }
+            },
+            "required": [
+              "service_reference"
+            ]
+          }
+        ]
+      },
+      "outputField": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/baseField"
+          },
+          {
+            "properties": {
+              "required": {
+                "type": "boolean",
+                "default": true
+              }
+            }
+          }
+        ]
+      },
+      "sourceReference": {
+        "type": "object",
+        "properties": {
+          "source_type": {
+            "type": "string"
+          },
+          "table": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "select_on": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "description",
+                "type",
+                "value"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "value": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/valueOperation"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "serviceReference": {
+        "type": "object",
+        "required": [
+          "service",
+          "field",
+          "law"
+        ],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "law": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "reference"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "reference": {
+                  "type": "string",
+                  "pattern": "^\\$[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+                }
+              }
+            }
+          }
+        }
+      },
+      "valueOperation": {
+        "type": "object",
+        "required": [
+          "operation"
+        ],
+        "properties": {
+          "operation": {
+            "type": "string",
+            "enum": [
+              "ADD",
+              "SUBTRACT",
+              "MULTIPLY",
+              "DIVIDE",
+              "IN",
+              "NOT_IN",
+              "EQUALS",
+              "NOT_EQUALS"
+            ]
+          },
+          "values": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/variableReference"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/variableReference"
+                    },
+                    {
+                      "type": [
+                        "number",
+                        "string"
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "operation": {
+        "type": "object",
+        "required": [
+          "operation"
+        ],
+        "properties": {
+          "operation": {
+            "type": "string",
+            "enum": [
+              "ADD",
+              "SUBTRACT",
+              "MULTIPLY",
+              "DIVIDE",
+              "MIN",
+              "MAX",
+              "AND",
+              "OR",
+              "NOT",
+              "EQUALS",
+              "NOT_EQUALS",
+              "GREATER_THAN",
+              "LESS_THAN",
+              "GREATER_OR_EQUAL",
+              "LESS_OR_EQUAL",
+              "IN",
+              "NOT_IN",
+              "CONCAT",
+              "IF",
+              "FOREACH",
+              "SUBTRACT_DATE",
+              "COALESCE",
+              "LENGTH",
+              "COMBINE_DATETIME",
+              "DAY_OF_WEEK"
+            ]
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/operationValue"
+            }
+          },
+          "subject": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "value": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "date": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "time": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "where": {
+            "description": "Optional filter condition for FOREACH operations - items are skipped if this evaluates to false",
+            "$ref": "#/definitions/operation"
+          },
+          "legal_basis": {
+            "$ref": "#/definitions/legalBasis"
+          }
+        },
+        "additionalProperties": false
+      },
+      "operationValue": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/variableReference"
+          },
+          {
+            "type": [
+              "number",
+              "boolean",
+              "null"
+            ]
+          },
+          {
+            "type": "string",
+            "not": {
+              "pattern": "^\\$"
+            }
+          },
+          {
+            "$ref": "#/definitions/operation"
+          }
+        ]
+      },
+      "action": {
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "output": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "ADD",
+              "SUBTRACT",
+              "MULTIPLY",
+              "DIVIDE",
+              "MIN",
+              "MAX",
+              "AND",
+              "OR",
+              "NOT",
+              "EQUALS",
+              "NOT_EQUALS",
+              "GREATER_THAN",
+              "LESS_THAN",
+              "GREATER_OR_EQUAL",
+              "LESS_OR_EQUAL",
+              "IN",
+              "NOT_IN",
+              "CONCAT",
+              "IF",
+              "FOREACH",
+              "SUBTRACT_DATE",
+              "COALESCE",
+              "LENGTH",
+              "COMBINE_DATETIME",
+              "DAY_OF_WEEK"
+            ]
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/operationValue"
+            }
+          },
+          "subject": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "date": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "time": {
+            "$ref": "#/definitions/operationValue"
+          },
+          "where": {
+            "description": "Optional filter condition for FOREACH operations - items are skipped if this evaluates to false",
+            "$ref": "#/definitions/operation"
+          },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "test": {
+                  "$ref": "#/definitions/operation"
+                },
+                "then": {
+                  "$ref": "#/definitions/operationValue"
+                },
+                "else": {
+                  "$ref": "#/definitions/operationValue"
+                },
+                "legal_basis": {
+                  "$ref": "#/definitions/legalBasis"
+                }
+              },
+              "required": [
+                "test",
+                "then"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "legal_basis": {
+            "$ref": "#/definitions/legalBasis"
+          }
+        },
+        "additionalProperties": false
+      },
+      "requirement": {
+        "type": "object",
+        "oneOf": [
+          {
+            "properties": {
+              "all": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/requirement"
+                }
+              }
+            },
+            "required": [
+              "all"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "any": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/requirement"
+                }
+              }
+            },
+            "required": [
+              "any"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "or": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/requirement"
+                }
+              }
+            },
+            "required": [
+              "or"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "EQUALS",
+                  "NOT_EQUALS",
+                  "GREATER_THAN",
+                  "LESS_THAN",
+                  "GREATER_OR_EQUAL",
+                  "LESS_OR_EQUAL",
+                  "IN",
+                  "NOT_IN",
+                  "IS_NULL",
+                  "NOT_NULL"
+                ]
+              },
+              "subject": {
+                "$ref": "#/definitions/variableReference"
+              },
+              "value": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/variableReference"
+                  },
+                  {
+                    "type": [
+                      "number",
+                      "boolean"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "not": {
+                      "pattern": "^\\$"
+                    }
+                  }
+                ]
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/variableReference"
+                    },
+                    {
+                      "type": [
+                        "number",
+                        "boolean"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "not": {
+                        "pattern": "^\\$"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "required": [
+              "operation"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "legalBasis": {
+        "type": "object",
+        "required": [
+          "law",
+          "url",
+          "explanation"
+        ],
+        "properties": {
+          "law": {
+            "type": "string",
+            "description": "Naam van de wet"
+          },
+          "bwb_id": {
+            "type": "string",
+            "pattern": "^BWBR[0-9]{7}$",
+            "description": "BWB identificatienummer van de wet"
+          },
+          "article": {
+            "type": "string",
+            "description": "Artikelnummer"
+          },
+          "paragraph": {
+            "type": "string",
+            "description": "Lid- of paragraafnummer"
+          },
+          "sentence": {
+            "type": "string",
+            "description": "Zinsnummer voor fijnmazige verwijzing"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL naar wetten.overheid.nl"
+          },
+          "juriconnect": {
+            "type": "string",
+            "pattern": "^jci1\\.3:c:BWBR[0-9]{7}(&[a-zA-Z_]+=.+)*$",
+            "description": "Juriconnect BWB 1.3 verwijzing"
+          },
+          "explanation": {
+            "type": "string",
+            "description": "Nederlandse uitleg hoe dit element zich verhoudt tot de wettekst"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }

--- a/script/validate.py
+++ b/script/validate.py
@@ -177,7 +177,7 @@ def validate_variable_definitions(yaml_files: List[Path]) -> None:
 
 def main():
     BASE_DIR = Path("laws")
-    schema = "schema/v0.1.7/schema.json"
+    schema = "schema/v0.1.8/schema.json"
 
     # Find all YAML files
     yaml_files = list(BASE_DIR.rglob("*.yaml")) + list(BASE_DIR.rglob("*.yml"))

--- a/web/demo_profiles.py
+++ b/web/demo_profiles.py
@@ -157,6 +157,63 @@ DEMO_PROFILES: dict[str, dict] = {
             ],
         },
     },
+    "geert": {
+        "name": "Geert",
+        "type": "vertegenwoordiger",
+        "bsn": "400100001",
+        "kvk": None,
+        "default_law_path": "zorgtoeslagwet/TOESLAGEN-2025-01-01",
+        "default_feature_path": "features/toeslagen/zorgtoeslagwet_TOESLAGEN-2025-01-01.feature",
+        "default_law_tabs": [
+            {
+                "id": "law-tab-1",
+                "path": "zorgtoeslagwet/TOESLAGEN-2025-01-01",
+                "name": "Zorgtoeslag",
+                "law": "zorgtoeslagwet",
+                "service": "TOESLAGEN",
+            },
+        ],
+        "zaaksysteem_service": "TOESLAGEN",
+        "portal_tab_label": "Burger.nl",
+        "portal_heading": "Waar heb ik recht op? Wat zijn mijn plichten?",
+        "portal_subtitle": "Bekijk hier uw toeslagen, uitkeringen, aangiften, en andere regelingen van de overheid.",
+        "feature_flags": {
+            "DELEGATION": True,
+            "AUTO_APPROVE_CLAIMS": False,
+            "HARMONIZE": False,
+            "SIMULATION": False,
+        },
+        "sidebar_laws": [
+            "zorgtoeslagwet/TOESLAGEN-2025-01-01",
+        ],
+        "graph_laws": None,
+        "graph_selected_laws": [],
+        "disabled_laws": {
+            "BELASTINGDIENST": ["zorgverzekeringswet/bijdrage", "zvw"],
+            "GEMEENTE_ROTTERDAM": [
+                "alcoholwet/vergunning",
+                "algemene_plaatselijke_verordening/exploitatievergunning",
+                "algemene_plaatselijke_verordening/terrassen",
+                "algemene_plaatselijke_verordening/ontheffingspas_geluid",
+                "verordening_precariobelasting",
+            ],
+            "KVK": ["handelsregisterwet/jaarrekening"],
+            "NVWA": ["warenwet/haccp", "warenwet/meldplicht"],
+            "PENSIOENFONDS": ["pensioenwet"],
+            "RVO": [
+                "omgevingswet/werkgebonden_personenmobiliteit",
+                "omgevingswet/energiebesparing/informatieplicht",
+            ],
+            "SVB": [
+                "algemene_kinderbijslagwet",
+                "algemene_nabestaandenwet",
+                "algemene_ouderdomswet/leeftijdsbepaling",
+                "algemene_ouderdomswet_gegevens",
+                "participatiewet/aio",
+            ],
+            "TOESLAGEN": ["wet_kinderopvang"],
+        },
+    },
 }
 
 DEFAULT_PROFILE = "merijn"

--- a/web/engines/http_engine/engine.py
+++ b/web/engines/http_engine/engine.py
@@ -162,7 +162,7 @@ class MachineService(EngineInterface):
         Get laws discoverable by citizens using HTTP calls to the Go backend service.
 
         Args:
-            discoverable_by: The type of entity discovering laws (CITIZEN, BUSINESS, DELEGATION_PROVIDER)
+            discoverable_by: The type of entity discovering laws (CITIZEN, BUSINESS, REPRESENTATION_PROVIDER)
             filter_disabled: If True, filter out laws disabled via feature flags. Set to False for admin UI.
 
         Returns:

--- a/web/engines/py_engine/engine.py
+++ b/web/engines/py_engine/engine.py
@@ -139,7 +139,7 @@ class PythonMachineService(EngineInterface):
         Get laws discoverable by citizens using the embedded Python machine.service library.
 
         Args:
-            discoverable_by: The type of entity discovering laws (CITIZEN, BUSINESS, DELEGATION_PROVIDER)
+            discoverable_by: The type of entity discovering laws (CITIZEN, BUSINESS, REPRESENTATION_PROVIDER)
             filter_disabled: If True, filter out laws disabled via feature flags. Set to False for admin UI.
 
         Returns:

--- a/web/routers/admin.py
+++ b/web/routers/admin.py
@@ -131,7 +131,7 @@ async def control(request: Request, services: EngineInterface = Depends(get_mach
     # Get all discoverable laws for each type (without feature flag filtering for admin UI)
     citizen_laws = services.get_discoverable_service_laws("CITIZEN", filter_disabled=False)
     business_laws = services.get_discoverable_service_laws("BUSINESS", filter_disabled=False)
-    delegation_laws = services.get_discoverable_service_laws("DELEGATION_PROVIDER", filter_disabled=False)
+    delegation_laws = services.get_discoverable_service_laws("REPRESENTATION_PROVIDER", filter_disabled=False)
 
     # Get the feature flags for each law type
     law_flags = {
@@ -299,7 +299,7 @@ async def post_set_feature_flag(
             # Get all discoverable laws for each type (without feature flag filtering for admin UI)
             citizen_laws = services.get_discoverable_service_laws("CITIZEN", filter_disabled=False)
             business_laws = services.get_discoverable_service_laws("BUSINESS", filter_disabled=False)
-            delegation_laws = services.get_discoverable_service_laws("DELEGATION_PROVIDER", filter_disabled=False)
+            delegation_laws = services.get_discoverable_service_laws("REPRESENTATION_PROVIDER", filter_disabled=False)
 
             # Get the feature flags for each law type
             law_flags = {

--- a/web/routers/delegation.py
+++ b/web/routers/delegation.py
@@ -81,6 +81,7 @@ async def get_current_context(request: Request, bsn: str):
             "subject_type": context.subject_type,
             "subject_name": context.subject_name,
             "delegation_type": context.delegation_type,
+            "legal_category": context.legal_category,
             "permissions": context.permissions,
         }
     return {"active": False, "actor_bsn": bsn}
@@ -106,8 +107,9 @@ async def list_delegations(
                 "subject_type": d.subject_type,
                 "subject_name": d.subject_name,
                 "delegation_type": d.delegation_type,
+                "legal_category": d.legal_category,
                 "permissions": d.permissions,
-                "valid_from": d.valid_from.isoformat(),
+                "valid_from": d.valid_from.isoformat() if d.valid_from else None,
                 "valid_until": d.valid_until.isoformat() if d.valid_until else None,
             }
             for d in delegations

--- a/web/templates/components/delegation_switcher.html
+++ b/web/templates/components/delegation_switcher.html
@@ -29,7 +29,15 @@
                 </div>
                 <div class="flex-grow truncate">
                     <div class="text-xs font-medium {% if delegation_context.subject_type == 'BUSINESS' %}text-amber-600{% else %}text-blue-600{% endif %}">
-                        Handelend namens
+                        {% if delegation_context.legal_category == 'BEVOEGDHEID' %}
+                            Bevoegd namens
+                        {% elif delegation_context.legal_category == 'MACHTIGING' %}
+                            Gemachtigd namens
+                        {% elif delegation_context.legal_category == 'VERTEGENWOORDIGING_VAN_RECHTSWEGE' %}
+                            Vertegenwoordiger van
+                        {% else %}
+                            Handelend namens
+                        {% endif %}
                     </div>
                     <div class="font-semibold truncate">{{ delegation_context.subject_name }}</div>
                 </div>
@@ -65,10 +73,9 @@
              class="absolute right-0 mt-2 w-[350px] bg-white rounded-md shadow-lg z-50 py-1 text-sm max-h-96 overflow-y-auto">
             <!-- Header -->
             <div class="px-3 py-2 text-xs font-medium text-gray-500 border-b border-gray-200">Handelen namens</div>
-            <!-- Delegations -->
+            <!-- SELF delegation -->
             {% for delegation in delegations %}
                 {% if delegation.subject_type == 'SELF' %}
-                    <!-- SELF delegation - reset to own context -->
                     <form action="/delegation/reset" method="POST" class="block">
                         <input type="hidden" name="bsn" value="{{ bsn }}">
                         <button type="submit"
@@ -95,48 +102,64 @@
                             {% endif %}
                         </button>
                     </form>
-                {% else %}
-                    <!-- Other delegations (BUSINESS, CITIZEN) -->
-                    <form action="/delegation/switch" method="POST" class="block">
-                        <input type="hidden" name="bsn" value="{{ bsn }}">
-                        <input type="hidden" name="subject_id" value="{{ delegation.subject_id }}">
-                        <button type="submit"
-                                class="w-full flex items-center px-4 py-3 hover:bg-gray-100 cursor-pointer border-b border-gray-100 text-left {% if delegation_context and delegation_context.subject_id == delegation.subject_id %}bg-blue-50{% endif %}">
-                            <div class="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 {% if delegation.subject_type == 'BUSINESS' %}bg-amber-100{% else %}bg-blue-100{% endif %}">
-                                {% if delegation.subject_type == 'BUSINESS' %}
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5 text-amber-600"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-                                    </svg>
-                                {% else %}
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-5 w-5 text-blue-600"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                                    </svg>
+                {% endif %}
+            {% endfor %}
+            <!-- Non-SELF delegations grouped by legal_category -->
+            {% set non_self = delegations|selectattr('subject_type', 'ne', 'SELF')|list %}
+            {% set category_labels = {
+                "BEVOEGDHEID": "Bevoegdheid",
+                "MACHTIGING": "Machtiging",
+                "VERTEGENWOORDIGING_VAN_RECHTSWEGE": "Vertegenwoordiging van rechtswege"
+            } %}
+            {% set categories = ["BEVOEGDHEID", "MACHTIGING", "VERTEGENWOORDIGING_VAN_RECHTSWEGE"] %}
+            {% for category in categories %}
+                {% set category_delegations = non_self|selectattr('legal_category', 'eq', category)|list %}
+                {% if category_delegations %}
+                    <div class="px-3 py-1.5 text-xs font-medium text-gray-400 uppercase tracking-wider bg-gray-50 border-b border-gray-200">
+                        {{ category_labels[category] }}
+                    </div>
+                    {% for delegation in category_delegations %}
+                        <form action="/delegation/switch" method="POST" class="block">
+                            <input type="hidden" name="bsn" value="{{ bsn }}">
+                            <input type="hidden" name="subject_id" value="{{ delegation.subject_id }}">
+                            <button type="submit"
+                                    class="w-full flex items-center px-4 py-3 hover:bg-gray-100 cursor-pointer border-b border-gray-100 text-left {% if delegation_context and delegation_context.subject_id == delegation.subject_id %}bg-blue-50{% endif %}">
+                                <div class="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 {% if delegation.subject_type == 'BUSINESS' %}bg-amber-100{% else %}bg-blue-100{% endif %}">
+                                    {% if delegation.subject_type == 'BUSINESS' %}
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5 text-amber-600"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                                        </svg>
+                                    {% else %}
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             class="h-5 w-5 text-blue-600"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                                        </svg>
+                                    {% endif %}
+                                </div>
+                                <div class="ml-3 flex-grow">
+                                    <div class="font-medium text-gray-900">{{ delegation.subject_name }}</div>
+                                    <div class="text-xs text-gray-500">
+                                        {{ delegation.delegation_type.replace('_', ' ').title() }}
+                                        {% if delegation.subject_type == 'BUSINESS' %}- KVK {{ delegation.subject_id }}{% endif %}
+                                    </div>
+                                </div>
+                                {% if delegation_context and delegation_context.subject_id == delegation.subject_id %}
+                                    <div class="ml-auto">
+                                        <svg class="h-5 w-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
                                 {% endif %}
-                            </div>
-                            <div class="ml-3 flex-grow">
-                                <div class="font-medium text-gray-900">{{ delegation.subject_name }}</div>
-                                <div class="text-xs text-gray-500">
-                                    {{ delegation.delegation_type.replace('_', ' ').title() }}
-                                    {% if delegation.subject_type == 'BUSINESS' %}- KVK {{ delegation.subject_id }}{% endif %}
-                                </div>
-                            </div>
-                            {% if delegation_context and delegation_context.subject_id == delegation.subject_id %}
-                                <div class="ml-auto">
-                                    <svg class="h-5 w-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                                    </svg>
-                                </div>
-                            {% endif %}
-                        </button>
-                    </form>
+                            </button>
+                        </form>
+                    {% endfor %}
                 {% endif %}
             {% endfor %}
         </div>


### PR DESCRIPTION
## Summary

- Rename `discoverable: "DELEGATION_PROVIDER"` to `"REPRESENTATION_PROVIDER"` throughout the codebase
- Add `legal_category` field to classify the 12 representation laws into three legally distinct categories:
  - **BEVOEGDHEID**: authority from law/position (machtigingenwet, gezag, minderjarigheid)
  - **MACHTIGING**: explicitly granted authority (volmacht)
  - **VERTEGENWOORDIGING_VAN_RECHTSWEGE**: court/law-mandated representation (curatele, mentorschap, beschermingsbewind, executeur, faillissementscurator, wsnp, wgbo, handelingsonbekwaamheid)
- Create schema v0.1.8 with new enum values
- Update delegation switcher UI to show category-specific labels ("Bevoegd namens", "Gemachtigd namens", "Vertegenwoordiger van") and group delegations by category

## Test plan

- [x] `uv run python script/validate.py` — all YAML laws validate against v0.1.8 schema
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `uv run behave features` — 45/46 features pass (1 pre-existing Playwright infra issue)
- [x] `cd features && go test -v .` — all Go tests pass
- [ ] Manual: run web UI, switch to Claudia profile, verify delegation switcher shows category-based labels and grouping