### PR TITLE
fix: refit graph view when container becomes visible

### DIFF
--- a/analysis/graph/src/routes/+page.svelte
+++ b/analysis/graph/src/routes/+page.svelte
@@ -14,6 +14,7 @@
     Position,
   } from '@xyflow/svelte';
   import LawNode from './LawNode.svelte';
+  import FitViewOnResize from './FitViewOnResize.svelte';
 
   // Import the styles for Svelte Flow to work
   import '@xyflow/svelte/dist/style.css';
@@ -662,6 +663,7 @@
     }}
     minZoom={0.1}
   >
+    <FitViewOnResize />
     <Controls showLock={false} />
     <Background variant={BackgroundVariant.Dots} />
     <MiniMap

--- a/analysis/graph/src/routes/FitViewOnResize.svelte
+++ b/analysis/graph/src/routes/FitViewOnResize.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { useSvelteFlow } from '@xyflow/svelte';
+  import { onMount } from 'svelte';
+
+  // Refit the view whenever the containing element transitions from zero to
+  // non-zero size. Needed because this app is embedded in an iframe inside a
+  // tab that starts hidden (display:none via Alpine's x-show), which causes
+  // SvelteFlow's initial fitView to run against a 0x0 container and lock the
+  // viewport at minZoom with a negative translate.
+  const { fitView } = $derived(useSvelteFlow());
+
+  onMount(() => {
+    const flow = document.querySelector('.svelte-flow') as HTMLElement | null;
+    if (!flow) return;
+
+    let lastWidth = flow.clientWidth;
+    let lastHeight = flow.clientHeight;
+
+    const ro = new ResizeObserver(() => {
+      const w = flow.clientWidth;
+      const h = flow.clientHeight;
+      const grewFromZero = (lastWidth === 0 || lastHeight === 0) && w > 0 && h > 0;
+      lastWidth = w;
+      lastHeight = h;
+      if (grewFromZero) {
+        // Next frame so SvelteFlow has measured nodes in the resized container.
+        requestAnimationFrame(() => fitView());
+      }
+    });
+    ro.observe(flow);
+    return () => ro.disconnect();
+  });
+</script>


### PR DESCRIPTION
## Summary

- The Graaf analyse tab lives in an iframe that starts hidden via Alpine's `x-show` (`display:none`). SvelteFlow's initial `fitView` therefore ran against a 0x0 container and locked the viewport at `minZoom=0.1` with a negative translate — all nodes ended up outside the visible area, so the tab appeared empty even though the laws and nodes were loaded correctly.
- Added a small `FitViewOnResize` child component inside `<SvelteFlow>` that uses a `ResizeObserver` on `.svelte-flow` and calls `fitView()` again once the container transitions from zero to non-zero size.

## Test plan

- [ ] Open `/demo/`, click the "Graaf analyse" tab without first having visited it — graph renders with the demo-selected laws centered in the viewport.
- [ ] Switch between tabs and back to "Graaf analyse" — graph stays correctly positioned.
- [ ] Open `/analysis/graph/?demo=true` directly — still works (the ResizeObserver only refits on the zero → non-zero transition).