### PR TITLE
chore: raise the Dependabot cooldown to five days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,36 @@
 version: 2
+
+# Cooldown: a release has to be five days old before Dependabot opens a version
+# update for it. Dependabot's own default has been three days since 2026-07-14;
+# raising it here also records the choice, so a future change to that default
+# cannot silently shrink the window.
+#
+# Five days is measured against how fast the registry compromises of the past
+# year surfaced - chalk/debug, shai-hulud, and the keyv/cacheable maintainer
+# hijack of 2026-08-04 were all detected within hours to days. Those are all
+# npm incidents; the same window is applied to the other ecosystems here for
+# consistency rather than from separate evidence. With `interval: weekly` the
+# practical delay is "at least five days, at most until the next weekly run".
+#
+# This applies to version updates only. Dependabot *security* updates are
+# exempt from cooldown and keep opening immediately, so advisory fixes are not
+# delayed by this.
 updates:
   # Docker
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
 
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       actions:
         patterns:
@@ -21,6 +41,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       python-minor-patch:
         update-types:
@@ -35,6 +57,8 @@ updates:
     directory: "/features"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       go-deps:
         patterns:
@@ -43,6 +67,8 @@ updates:
     directory: "/lac-to-regelspraak"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       go-deps:
         patterns:
@@ -51,6 +77,8 @@ updates:
     directory: "/machinev2/backend"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       go-deps:
         patterns:
@@ -59,6 +87,8 @@ updates:
     directory: "/machinev2/machine"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       go-deps:
         patterns:
@@ -67,6 +97,8 @@ updates:
     directory: "/simulator"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       go-deps:
         patterns:
@@ -77,6 +109,8 @@ updates:
     directory: "/analysis/graph"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       npm-minor-patch:
         update-types:
@@ -86,6 +120,8 @@ updates:
     directory: "/analysis/laws"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       npm-minor-patch:
         update-types:
@@ -95,6 +131,8 @@ updates:
     directory: "/importer"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
Sets `cooldown: default-days: 5` on all 11 update blocks in `.github/dependabot.yml`, with the rationale as a file-level comment.

## What this actually changes

Dependabot has applied a **three-day cooldown by default since 2026-07-14**. So this is 3 → 5 days, not 0 → 5. The explicit setting also pins the choice, so a later change to that default cannot silently shrink the window.

Five days is measured against how fast the registry compromises of the past year surfaced: chalk/debug, shai-hulud, and the keyv/cacheable maintainer-account hijack of 2026-08-04 were all detected within hours to days. With `interval: weekly` the practical delay is *at least* five days and at most until the next weekly run.

Cooldown covers **version** updates only — Dependabot security updates are exempt and keep opening immediately, so advisory fixes are not delayed.

## Context

`analysis/graph`, `analysis/laws` and `importer` carry `keyv@4.5.4` / `file-entry-cache@8.0.0` transitively via eslint. Both are far below the poisoned releases (6.0.0 / 11.1.6) and pinned in `pnpm-lock.yaml`, so **nothing here is compromised** — this is prevention.

## Notes

- `default-days` is supported for every ecosystem used here (docker, github-actions, uv, gomod, npm).
- The value has to be repeated per block; Dependabot has no shared-defaults section.
- Related: #501 adds `--ignore-scripts` to the node installs in the Dockerfile.