### PR TITLE
ci: install node dependencies with --ignore-scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,25 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /analysis-laws
 COPY analysis/laws/.eslintrc.cjs analysis/laws/.npmrc analysis/laws/.prettierrc analysis/laws/package.json analysis/laws/pnpm-lock.yaml analysis/laws/postcss.config.js analysis/laws/svelte.config.js analysis/laws/tailwind.config.js analysis/laws/tsconfig.json analysis/laws/vite.config.ts ./
 
-RUN pnpm install --package-import-method=hardlink
+# --ignore-scripts on the pnpm installs is mostly about being explicit, and it
+# also un-breaks this build. pnpm >= 10 already refuses dependency build
+# scripts by default, and `corepack prepare pnpm@latest` has been resolving to
+# such a version since June - which is why `docker-build` has failed on main
+# since 2026-06-12 with ERR_PNPM_IGNORED_BUILDS on esbuild. That error is
+# pnpm's "decide about this" gate, not a real need: esbuild's postinstall only
+# hardlinks a CLI shim, and the binary that matters comes from the
+# platform-specific optional dependency. We decide to skip it.
+#
+# Note the trade-off. This flag also silences the same gate for a future
+# dependency that does need its build step. pnpm's in-repo alternatives
+# (onlyBuiltDependencies / ignoredBuiltDependencies, in package.json or
+# pnpm-workspace.yaml) would have been the better instrument, but neither
+# satisfies strictDepBuilds in pnpm 11.20.0 - verified by hand; both still exit
+# 1. Revisit when pnpm fixes that.
+#
+# The apps' own `prepare: svelte-kit sync` is not needed at install time: the
+# SvelteKit vite plugin syncs during `pnpm run build`.
+RUN pnpm install --ignore-scripts --package-import-method=hardlink
 
 COPY analysis/laws/. .
 
@@ -17,7 +35,7 @@ RUN pnpm run build
 WORKDIR /analysis-graph
 COPY analysis/graph/.eslintrc.cjs analysis/graph/.npmrc analysis/graph/.prettierrc analysis/graph/package.json analysis/graph/pnpm-lock.yaml analysis/graph/postcss.config.js analysis/graph/svelte.config.js analysis/graph/tailwind.config.js analysis/graph/tsconfig.json analysis/graph/vite.config.ts ./
 
-RUN pnpm install --package-import-method=hardlink
+RUN pnpm install --ignore-scripts --package-import-method=hardlink
 
 COPY analysis/graph/. .
 
@@ -27,7 +45,7 @@ RUN pnpm run build
 WORKDIR /importer
 COPY importer/.eslintrc.cjs importer/.npmrc importer/.prettierrc importer/package.json importer/pnpm-lock.yaml importer/postcss.config.js importer/svelte.config.js importer/tailwind.config.js importer/tsconfig.json importer/vite.config.ts ./
 
-RUN pnpm install --package-import-method=hardlink
+RUN pnpm install --ignore-scripts --package-import-method=hardlink
 
 COPY importer/. .
 
@@ -44,7 +62,9 @@ COPY wallet/nl-wallet ./nl-wallet
 # Build wallet-web
 WORKDIR /wallet/nl-wallet/wallet_web
 ENV VITE_HELP_BASE_URL="https://example.com"
-RUN npm ci && npm run build
+# --ignore-scripts: same reason as the pnpm installs above. wallet_web declares
+# no prepare/postinstall of its own; `vite build` is all this stage needs.
+RUN npm ci --ignore-scripts && npm run build
 
 # Collect all required wallet files into a single directory
 WORKDIR /wallet-files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,61 @@
 ## Build Stage 1: build the SvelteKit app
 FROM node:24-alpine3.21 AS node_builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm is pinned rather than `pnpm@latest`: this stage runs in the job that
+# pushes to GHCR with `packages: write` (.github/workflows/docker-build.yml),
+# so the package manager is itself part of this image's supply chain and should
+# not be whatever npm published most recently. `latest` also moved from pnpm 10
+# to pnpm 11 on 2026-04-28 and broke this build from 2026-06-12 onwards (see
+# below); pnpm 12 is already in beta. Nothing bumps this automatically -
+# Dependabot's docker ecosystem only tracks FROM lines, and no other job runs
+# pnpm - so bump it deliberately when you touch this file.
+RUN corepack enable && corepack prepare pnpm@11.20.0 --activate
 
 # Copy and build analysis/laws
 WORKDIR /analysis-laws
 COPY analysis/laws/.eslintrc.cjs analysis/laws/.npmrc analysis/laws/.prettierrc analysis/laws/package.json analysis/laws/pnpm-lock.yaml analysis/laws/postcss.config.js analysis/laws/svelte.config.js analysis/laws/tailwind.config.js analysis/laws/tsconfig.json analysis/laws/vite.config.ts ./
 
-# --ignore-scripts on the pnpm installs is mostly about being explicit, and it
-# also un-breaks this build. pnpm >= 10 already refuses dependency build
-# scripts by default, and `corepack prepare pnpm@latest` has been resolving to
-# such a version since June - which is why `docker-build` has failed on main
-# since 2026-06-12 with ERR_PNPM_IGNORED_BUILDS on esbuild. That error is
-# pnpm's "decide about this" gate, not a real need: esbuild's postinstall only
-# hardlinks a CLI shim, and the binary that matters comes from the
-# platform-specific optional dependency. We decide to skip it.
+# Both flags below apply to all three pnpm installs in this stage.
 #
-# Note the trade-off. This flag also silences the same gate for a future
-# dependency that does need its build step. pnpm's in-repo alternatives
-# (onlyBuiltDependencies / ignoredBuiltDependencies, in package.json or
-# pnpm-workspace.yaml) would have been the better instrument, but neither
-# satisfies strictDepBuilds in pnpm 11.20.0 - verified by hand; both still exit
-# 1. Revisit when pnpm fixes that.
+# --ignore-scripts: a dependency's install script runs with the same GHCR-write
+# token this job holds, which is exactly the path a hijacked npm package uses.
+# Under the pinned pnpm 11 nothing would run one anyway - pnpm errors instead,
+# see below - so the flag is here to record the decision explicitly, and to keep
+# holding if a pnpm default changes, an `allowBuilds` entry appears, or an app
+# moves back to npm. Nothing in these three apps needs one.
+#
+# --frozen-lockfile: `CI` is not set inside a Docker build, so pnpm does not
+# freeze by default. Without it, package.json drifting from pnpm-lock.yaml
+# makes pnpm re-resolve the semver ranges at build time and the lockfile's
+# pinned versions are silently bypassed. The cost is that no pull request
+# exercises this - docker-build runs only on push to main, plus manual
+# dispatch - so a package.json/lockfile mismatch now fails the publish after
+# merge rather than being absorbed. Keep pnpm-lock.yaml in the same commit as
+# package.json.
+#
+# --ignore-scripts also un-breaks this build. pnpm 10 already declined to run
+# dependency build scripts, but only warned about it and exited 0; pnpm 11
+# (2026-04-28) flipped `strictDepBuilds` to true by default and made that
+# warning a hard error, so the first push to main afterwards (2026-06-12)
+# failed with ERR_PNPM_IGNORED_BUILDS on esbuild. That error is pnpm asking us
+# to decide, not a build we actually need: esbuild's postinstall hardlinks the
+# platform-specific optional dependency's native binary over its JS shim as a
+# startup optimisation (and downloads that binary itself if the optional
+# dependency is missing). Skipped, the shim resolves the same binary lazily at
+# runtime. We decide to skip it.
+#
+# Note the trade-off: the flag also silences that gate for a future dependency
+# that does need its build step. pnpm's instrument for that is `allowBuilds`, a
+# package-pattern -> bool map; pnpm 11 removed onlyBuiltDependencies,
+# ignoredBuiltDependencies and friends in its favour. `allowBuilds:
+# {esbuild: false}` does satisfy the gate, but pnpm 11 no longer reads settings
+# from package.json's `pnpm` field at all - only pnpm-workspace.yaml - so it
+# would need a new pnpm-workspace.yaml per app plus an extra entry in each of
+# the three COPY lists here. We keep the flag instead.
 #
 # The apps' own `prepare: svelte-kit sync` is not needed at install time: the
 # SvelteKit vite plugin syncs during `pnpm run build`.
-RUN pnpm install --ignore-scripts --package-import-method=hardlink
+RUN pnpm install --ignore-scripts --frozen-lockfile --package-import-method=hardlink
 
 COPY analysis/laws/. .
 
@@ -35,7 +65,8 @@ RUN pnpm run build
 WORKDIR /analysis-graph
 COPY analysis/graph/.eslintrc.cjs analysis/graph/.npmrc analysis/graph/.prettierrc analysis/graph/package.json analysis/graph/pnpm-lock.yaml analysis/graph/postcss.config.js analysis/graph/svelte.config.js analysis/graph/tailwind.config.js analysis/graph/tsconfig.json analysis/graph/vite.config.ts ./
 
-RUN pnpm install --ignore-scripts --package-import-method=hardlink
+# --ignore-scripts, --frozen-lockfile: see the analysis/laws install above.
+RUN pnpm install --ignore-scripts --frozen-lockfile --package-import-method=hardlink
 
 COPY analysis/graph/. .
 
@@ -45,7 +76,8 @@ RUN pnpm run build
 WORKDIR /importer
 COPY importer/.eslintrc.cjs importer/.npmrc importer/.prettierrc importer/package.json importer/pnpm-lock.yaml importer/postcss.config.js importer/svelte.config.js importer/tailwind.config.js importer/tsconfig.json importer/vite.config.ts ./
 
-RUN pnpm install --ignore-scripts --package-import-method=hardlink
+# --ignore-scripts, --frozen-lockfile: see the analysis/laws install above.
+RUN pnpm install --ignore-scripts --frozen-lockfile --package-import-method=hardlink
 
 COPY importer/. .
 
@@ -62,8 +94,16 @@ COPY wallet/nl-wallet ./nl-wallet
 # Build wallet-web
 WORKDIR /wallet/nl-wallet/wallet_web
 ENV VITE_HELP_BASE_URL="https://example.com"
-# --ignore-scripts: same reason as the pnpm installs above. wallet_web declares
-# no prepare/postinstall of its own; `vite build` is all this stage needs.
+# --ignore-scripts: unlike pnpm, npm still runs *dependency* install scripts by
+# default, so this is the one install here where the flag stops a dependency
+# from executing - esbuild's postinstall did run and now won't. (In the pnpm
+# stage pnpm 11 was already refusing those, and the flag only additionally
+# suppresses the apps' own `prepare`.) At the pinned submodule commit wallet_web
+# declares no install script of its own, and its only script-bearing
+# dependencies are esbuild (see above) and fsevents (macOS-only, so never built
+# here); `vite build` is all this stage needs.
+# No --frozen-lockfile: `npm ci` already refuses to run if package.json and
+# package-lock.json disagree.
 RUN npm ci --ignore-scripts && npm run build
 
 # Collect all required wallet files into a single directory


### PR DESCRIPTION
Adds `--ignore-scripts` to the three `pnpm install` calls and the one `npm ci` in the Dockerfile — the only place this repo installs node dependencies in CI.

## Why

Dependabot resolves with `--ignore-scripts`, so the PR it opens is harmless in itself. The exposure is the install: it runs every dependency's `preinstall`/`postinstall` hook, and here that happens in the job that pushes to GHCR (`packages: write`). Every registry compromise of the past year — chalk/debug, shai-hulud, and the keyv/cacheable maintainer-account hijack of 2026-08-04 — delivered its payload through exactly that hook.

## Two things to know before merging

**1. For the pnpm installs the security gain is small.** pnpm ≥ 10 already refuses dependency build scripts by default, and `corepack prepare pnpm@latest` has been resolving to such a version for months. The flag is real protection only for the `npm ci` in `wallet_web`. For the pnpm lines it is mostly making an existing default explicit.

**2. This un-breaks `docker-build`.** That workflow has failed on `main` since **2026-06-12** with `ERR_PNPM_IGNORED_BUILDS: esbuild@0.27.2` — most recently [run 30931082705](https://github.com/MinBZK/poc-machine-law/actions/runs/30931082705). That is pnpm's "decide about this" gate, not a genuine need: esbuild's postinstall only hardlinks a CLI shim, and the binary that matters comes from the platform-specific optional dependency. Skipping it is the right decision, but you should merge this knowing it is *also* fixing a two-month-old red build, not only hardening.

The trade-off: the gate is now silent for a future dependency that genuinely needs its build step. pnpm's in-repo alternatives would be the better instrument, but I tested `onlyBuiltDependencies: []` and `ignoredBuiltDependencies` in both `package.json` and `pnpm-workspace.yaml` against pnpm 11.20.0 and **none of them satisfies `strictDepBuilds`** — all still exit 1. Only `--ignore-scripts` or `strictDepBuilds: false` works today. Recorded in a comment in the Dockerfile.

## Verification

The three SvelteKit apps declare `"prepare": "svelte-kit sync"`, which `--ignore-scripts` skips. That is fine: the SvelteKit vite plugin runs sync during the build. Proven — `pnpm install --ignore-scripts --package-import-method=hardlink` followed by `pnpm run build` produces a complete `build/` (adapter-static reports done). `wallet_web` declares no install scripts at all, checked at the pinned submodule commit `294608f`.

Note `docker-build.yml` runs on push to `main`, not on pull requests, so CI on this PR does not exercise the Dockerfile. The local runs above are the evidence. A `workflow_dispatch` run before merging would remove the last doubt.

## Related

#500 (merged) raises the Dependabot cooldown to five days.