### PR TITLE
ci: geef de testworkflows een read-only token

### DIFF
--- a/.github/workflows/test-behaviour.yml
+++ b/.github/workflows/test-behaviour.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# The two Go jobs already declared this; the `test` job did not, so it ran with
+# whatever the repository default is. That job runs `uv sync` and the whole
+# behave suite, which executes every Python dependency in the lockfile. None of
+# that needs a token that can write to this repository.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -58,10 +65,6 @@ jobs:
   go-test-features:
     name: Run Go Features
     runs-on: ubuntu-latest
-    # Add this permissions block
-    permissions:
-      # Set only what you need
-      contents: read
 
     steps:
       - name: Checkout code
@@ -83,10 +86,6 @@ jobs:
   go-test-machinev2:
     name: Run Go Tests
     runs-on: ubuntu-latest
-    # Add this permissions block
-    permissions:
-      # Set only what you need
-      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test-behaviour.yml
+++ b/.github/workflows/test-behaviour.yml
@@ -6,10 +6,9 @@ on:
   pull_request:
     branches: [main]
 
-# The two Go jobs already declared this; the `test` job did not, so it ran with
-# whatever the repository default is. That job runs `uv sync` and the whole
-# behave suite, which executes every Python dependency in the lockfile. None of
-# that needs a token that can write to this repository.
+# These jobs pull in and run third-party code: the Python dependency tree, the
+# Go module tree, and a Playwright browser download. None of it needs a token
+# that can write to this repository.
 permissions:
   contents: read
 

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+# This workflow declared no permissions at all, so it ran with whatever the
+# repository default is. It runs `uv sync`, installs a Playwright browser and
+# executes the test suite - the whole Python dependency tree gets to run. None
+# of that needs a token that can write to this repository.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -6,10 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
-# This workflow declared no permissions at all, so it ran with whatever the
-# repository default is. It runs `uv sync`, installs a Playwright browser and
-# executes the test suite - the whole Python dependency tree gets to run. None
-# of that needs a token that can write to this repository.
+# This job pulls in and runs third-party code: the Python dependency tree and
+# three Playwright browser engines. None of it needs a token that can write to
+# this repository.
 permissions:
   contents: read
 


### PR DESCRIPTION
Voegt `permissions: contents: read` toe aan `test-ui.yml` en `test-behaviour.yml`.

## Het probleem

`test-ui.yml` had als enige workflow in deze repo **helemaal geen `permissions:`-blok**, en in `test-behaviour.yml` gold dat voor de `test`-job (de twee Go-jobs hadden het wel). Die jobs erven dus de repo-default.

Beide draaien `uv sync` plus de volledige testsuite, en `test-ui` installeert er ook nog een Playwright-browser bij. Daarmee komt de hele Python-dependencyboom aan uitvoering toe, op **elke pull request en elke push**. Geen van die stappen hoeft naar deze repo te kunnen schrijven.

## Opgeruimd

De twee job-blokken in `test-behaviour.yml` zijn weg: die zeiden precies wat de workflow-default nu zegt, inclusief de overgebleven template-comments (`# Add this permissions block`, `# Set only what you need`). Job-level permissions overschrijven workflow-level volledig, dus dit verandert niets aan wat die Go-jobs krijgen.

## Nog open in deze repo

Uit dezelfde review, bewust niet in deze PR:
- `curl -LsSf https://astral.sh/uv/install.sh | sh` in beide workflows — ongepind en niet geverifieerd, uitgevoerd op elke PR.
- `uv pip install pytest-playwright` in `test-ui.yml` staat buiten de lockfile.
- De 17 actions in deze repo staan allemaal op een zwevende tag, waaronder `int128/kaniko-action@v1` in de job met `packages: write`.