### PR TITLE
feat: toon verhuisbericht naar demo.regelrecht.rijks.app

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -100,9 +100,64 @@
     <link rel="manifest" href="/static/img/site.webmanifest" />
 </head>
 <body class="min-h-screen bg-gray-50">
+    <!-- Verhuisbericht modal -->
+    <div x-data="{ showMoveModal: localStorage.getItem('regelrecht-move-notice-dismissed') !== 'true' }"
+         x-show="showMoveModal"
+         x-cloak
+         style="display: none"
+         @keydown.escape.window="showMoveModal = false; localStorage.setItem('regelrecht-move-notice-dismissed', 'true')"
+         class="fixed inset-0 z-[11000] flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-black/50"
+             @click="showMoveModal = false; localStorage.setItem('regelrecht-move-notice-dismissed', 'true')"></div>
+        <div class="relative bg-white rounded-lg shadow-xl max-w-lg w-full p-6"
+             role="dialog"
+             aria-modal="true"
+             aria-labelledby="move-notice-title"
+             x-transition:enter="transition ease-out duration-200"
+             x-transition:enter-start="opacity-0 transform scale-95"
+             x-transition:enter-end="opacity-100 transform scale-100">
+            <button @click="showMoveModal = false; localStorage.setItem('regelrecht-move-notice-dismissed', 'true')"
+                    class="absolute top-4 right-4 text-gray-400 hover:text-gray-600 focus:outline-none rounded-lg p-1 cursor-pointer"
+                    aria-label="Sluiten">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+            </button>
+            <h2 id="move-notice-title"
+                class="text-xl font-semibold text-gray-900 pr-8">Deze demo verhuist</h2>
+            <p class="mt-3 text-sm text-gray-700">
+                Er staat een nieuwe versie van RegelRecht klaar: een nieuw ontwerp, een nieuwe
+                implementatie onder de motorkap en een eigen adres:
+            </p>
+            <a href="https://demo.regelrecht.rijks.app"
+               class="mt-3 inline-flex items-center text-base font-medium text-blue-600 hover:text-blue-800 break-all">
+                demo.regelrecht.rijks.app
+                <svg class="ml-1 w-4 h-4 flex-shrink-0"
+                     fill="none"
+                     stroke="currentColor"
+                     viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+            </a>
+            <p class="mt-3 text-xs text-gray-600">
+                Deze omgeving is de oude proof of concept en blijft voorlopig nog beschikbaar, maar
+                wordt niet meer doorontwikkeld. Werk uw bladwijzers bij.
+            </p>
+            <div class="mt-6 flex flex-wrap gap-3">
+                <a href="https://demo.regelrecht.rijks.app"
+                   class="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700">
+                    Naar de nieuwe RegelRecht
+                </a>
+                <button @click="showMoveModal = false; localStorage.setItem('regelrecht-move-notice-dismissed', 'true')"
+                        class="inline-flex items-center px-4 py-2 rounded-md border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 cursor-pointer">
+                    Hier verder
+                </button>
+            </div>
+        </div>
+    </div>
     {% if not demo_mode %}
         <!-- Proof of Concept Ribbon -->
-        <button onclick="localStorage.removeItem('regelrecht-banner-dismissed'); location.reload();"
+        <button onclick="localStorage.removeItem('regelrecht-banner-dismissed'); localStorage.removeItem('regelrecht-move-notice-dismissed'); location.reload();"
                 class="fixed z-[10000] w-[180px] top-[30px] right-[-50px] text-center text-[15px] font-medium py-[5px] bg-[#FACC15] text-black transform rotate-45 origin-center shadow-md hover:bg-[#EAB308] transition-colors no-underline cursor-pointer border-0">
             Proof of Concept
         </button>


### PR DESCRIPTION
Bezoekers van deze demo krijgen bij het openen een wegklikbare modal die vertelt dat RegelRecht is verhuisd naar https://demo.regelrecht.rijks.app, met een nieuw ontwerp en een nieuwe implementatie.

De modal zit in `base.html`, dus hij verschijnt op zowel het dashboard als de chat. Wegklikken kan via de kruisknop, de knop "Hier verder", de Escape-toets of een klik naast de modal. De keuze wordt onthouden in localStorage onder `regelrecht-move-notice-dismissed`. De bestaande Proof of Concept-ribbon wist die sleutel nu samen met de al bestaande bannersleutel, zodat het bericht terug te halen is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDTpswnU1E2A2s4Li7brxb